### PR TITLE
Upgrade linter to use pipenv

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -6,9 +6,10 @@ verify_ssl = true
 [dev-packages]
 
 [packages]
-python-frontmatter = "==0.4.5"
-fire = "==0.3.0"
-youtube_dl = "==2020.3.8"
+python-frontmatter = ">=0.4.5"
+fire = ">=0.3.0"
+youtube_dl = ">=2020.3.8"
+urllib3 = "==1.25.9"
 
 [requires]
 python_version = "3.8"

--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,14 @@
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true
+
+[dev-packages]
+
+[packages]
+python-frontmatter = "==0.4.5"
+fire = "==0.3.0"
+youtube_dl = "==2020.3.8"
+
+[requires]
+python_version = "=>3.8"

--- a/Pipfile
+++ b/Pipfile
@@ -11,4 +11,4 @@ fire = "==0.3.0"
 youtube_dl = "==2020.3.8"
 
 [requires]
-python_version = "=>3.8"
+python_version = "3.8"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "62ca5ffb9ce8549e0108ff5263c33ea6043bdc1de70e0e3d45d55bd3d4772c9d"
+            "sha256": "245a84dc5422228fde75ae97df473752e74e623f8d3543f2b5f160157862f2b6"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "=>3.8"
+            "python_version": "3.8"
         },
         "sources": [
             {
@@ -52,7 +52,7 @@
                 "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259",
                 "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==1.15.0"
         },
         "termcolor": {

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "245a84dc5422228fde75ae97df473752e74e623f8d3543f2b5f160157862f2b6"
+            "sha256": "752f3e444d2851fe566cfacdc5d87395c795a645f729a4dae264b028da4183c8"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -18,18 +18,18 @@
     "default": {
         "fire": {
             "hashes": [
-                "sha256:96c372096afcf33ddbadac8a7ca5b7e829e8d7157d0030bd964bf959afde5c2c"
+                "sha256:9736a16227c3d469e5d2d296bce5b4d8fa8d7851e953bda327a455fc2994307f"
             ],
             "index": "pypi",
-            "version": "==0.3.0"
+            "version": "==0.3.1"
         },
         "python-frontmatter": {
             "hashes": [
-                "sha256:13a61749910f2e1968c011103406429abc79c41d52b69adfb07f702ae2df32cc",
-                "sha256:cec75b2afd1a06cf5b03cfd9c5173365d3dc14379526389a9742ff35846df771"
+                "sha256:a7dcdfdaf498d488dce98bfa9452f8b70f803a923760ceab1ebd99291d98d28a",
+                "sha256:a9c2e90fc38e9f0c68d8b82299040f331ca3b8525ac7fa5f6beffef52b26c426"
             ],
             "index": "pypi",
-            "version": "==0.4.5"
+            "version": "==0.5.0"
         },
         "pyyaml": {
             "hashes": [
@@ -52,7 +52,7 @@
                 "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259",
                 "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.15.0"
         },
         "termcolor": {
@@ -61,13 +61,21 @@
             ],
             "version": "==1.1.0"
         },
-        "youtube-dl": {
+        "urllib3": {
             "hashes": [
-                "sha256:1b098b7ae41551f46dbae70e56dbabdf39c8faf50e072d0c0b42c44d64afebf8",
-                "sha256:f9d33129ea4941bea234cdba811c0f97e61c2235a877cf395a869aeea065e009"
+                "sha256:3018294ebefce6572a474f0604c2021e33b3fd8006ecd11d62107a5d2a963527",
+                "sha256:88206b0eb87e6d677d424843ac5209e3fb9d0190d0ee169599165ec25e9d9115"
             ],
             "index": "pypi",
-            "version": "==2020.3.8"
+            "version": "==1.25.9"
+        },
+        "youtube-dl": {
+            "hashes": [
+                "sha256:012de159061570a6107e2da9a24d9ce628f045604471192f4b66236a6915a1f8",
+                "sha256:67fb9bfa30f5b8f06227c478a8a6ed04af1f97ad4e81dd7e2ce518df3e275391"
+            ],
+            "index": "pypi",
+            "version": "==2020.9.20"
         }
     },
     "develop": {}

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,74 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "62ca5ffb9ce8549e0108ff5263c33ea6043bdc1de70e0e3d45d55bd3d4772c9d"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "=>3.8"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "fire": {
+            "hashes": [
+                "sha256:96c372096afcf33ddbadac8a7ca5b7e829e8d7157d0030bd964bf959afde5c2c"
+            ],
+            "index": "pypi",
+            "version": "==0.3.0"
+        },
+        "python-frontmatter": {
+            "hashes": [
+                "sha256:13a61749910f2e1968c011103406429abc79c41d52b69adfb07f702ae2df32cc",
+                "sha256:cec75b2afd1a06cf5b03cfd9c5173365d3dc14379526389a9742ff35846df771"
+            ],
+            "index": "pypi",
+            "version": "==0.4.5"
+        },
+        "pyyaml": {
+            "hashes": [
+                "sha256:06a0d7ba600ce0b2d2fe2e78453a470b5a6e000a985dd4a4e54e436cc36b0e97",
+                "sha256:240097ff019d7c70a4922b6869d8a86407758333f02203e0fc6ff79c5dcede76",
+                "sha256:4f4b913ca1a7319b33cfb1369e91e50354d6f07a135f3b901aca02aa95940bd2",
+                "sha256:69f00dca373f240f842b2931fb2c7e14ddbacd1397d57157a9b005a6a9942648",
+                "sha256:73f099454b799e05e5ab51423c7bcf361c58d3206fa7b0d555426b1f4d9a3eaf",
+                "sha256:74809a57b329d6cc0fdccee6318f44b9b8649961fa73144a98735b0aaf029f1f",
+                "sha256:7739fc0fa8205b3ee8808aea45e968bc90082c10aef6ea95e855e10abf4a37b2",
+                "sha256:95f71d2af0ff4227885f7a6605c37fd53d3a106fcab511b8860ecca9fcf400ee",
+                "sha256:b8eac752c5e14d3eca0e6dd9199cd627518cb5ec06add0de9d32baeee6fe645d",
+                "sha256:cc8955cfbfc7a115fa81d85284ee61147059a753344bc51098f3ccd69b0d7e0c",
+                "sha256:d13155f591e6fcc1ec3b30685d50bf0711574e2c0dfffd7644babf8b5102ca1a"
+            ],
+            "version": "==5.3.1"
+        },
+        "six": {
+            "hashes": [
+                "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259",
+                "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.15.0"
+        },
+        "termcolor": {
+            "hashes": [
+                "sha256:1d6d69ce66211143803fbc56652b41d73b4a400a2891d7bf7a1cdf4c02de613b"
+            ],
+            "version": "==1.1.0"
+        },
+        "youtube-dl": {
+            "hashes": [
+                "sha256:1b098b7ae41551f46dbae70e56dbabdf39c8faf50e072d0c0b42c44d64afebf8",
+                "sha256:f9d33129ea4941bea234cdba811c0f97e61c2235a877cf395a869aeea065e009"
+            ],
+            "index": "pypi",
+            "version": "==2020.3.8"
+        }
+    },
+    "develop": {}
+}

--- a/README.md
+++ b/README.md
@@ -70,23 +70,21 @@ That's it :) now you'll be able to poke around the main site
 Make sure you have Python3 installed. This wont work with legacy Python (python2.7 == legacy == dangerzone).
 
 ```
-# make a virtual environment
-python3 -m venv venv
+# with Pipenv installed there is no need to create a virtual environment, so go ahead and install it if you haven't already
+pip install pipenv
 
-# if you name your virtual env anything other than venv,
-# please be careful to not commit it to git!
+# Pipenv will automatically create a virtual environment and install all required packages for this repo, simply type the following
+pipenv install
 
-# activate it
-
-source venv/bin/activate
-
-# install dependencies
-
-pip install -r requirements.txt
-
-# and run the linter
-
+# activate Pipenv virtual environment and run the linter
+pipenv shell
 python lint.py
+
+# to install new packages simply use pipenv and it will install and automatically update the Pipfile and Pipfile.lock  with the newly 
+# installed package
+# for example, if you want to install pandas:
+pipenv install pandas
+
 ```
 
 Then if you want to run the linter again, you dont need to do the whole setup again. Do this:

--- a/README.md
+++ b/README.md
@@ -95,6 +95,11 @@ pipenv shell
 python lint.py
 
 ```
+### Reference Links on Pipenv
+- https://www.infoworld.com/article/3561758/how-to-manage-python-projects-with-pipenv.html
+- https://realpython.com/pipenv-guide/
+- https://pipenv-fork.readthedocs.io/en/latest/basics.html
+- https://www.youtube.com/watch?v=6Qmnh5C4Pmo
 
 The linter starts off by looking over all the frontmatter and making sure that's fine. Then it builds the site and looks for trouble.
 

--- a/README.md
+++ b/README.md
@@ -73,15 +73,16 @@ Make sure you have Python3 installed. This wont work with legacy Python (python2
 # with Pipenv installed there is no need to create a virtual environment, so go ahead and install it if you haven't already
 pip install pipenv
 
-# Pipenv will automatically create a virtual environment and install all required packages for this repo, simply type the following
+# Pipenv will automatically create a virtual environment and install all required packages for this repo, simply type the 
+# following:
 pipenv install
 
 # activate Pipenv virtual environment and run the linter
 pipenv shell
 python lint.py
 
-# to install any new packages simply use pipenv and it will install and automatically update the Pipfile and Pipfile.lock  with the newly 
-# installed package
+# to install any new packages simply use pipenv and it will install and automatically update the Pipfile and Pipfile.lock
+# with the newly installed package 
 # for example, if you want to install pandas:
 pipenv install pandas
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ hugo serve -b "http://localhost:1313/"
 
 That's it :) now you'll be able to poke around the main site
 
-### Setting up and running the linter
+### Setting up and running the linter with using Pipenv
 
 Make sure you have Python3 installed. This wont work with legacy Python (python2.7 == legacy == dangerzone).
 
@@ -80,20 +80,18 @@ pipenv install
 pipenv shell
 python lint.py
 
-# to install new packages simply use pipenv and it will install and automatically update the Pipfile and Pipfile.lock  with the newly 
+# to install any new packages simply use pipenv and it will install and automatically update the Pipfile and Pipfile.lock  with the newly 
 # installed package
 # for example, if you want to install pandas:
 pipenv install pandas
 
 ```
 
-Then if you want to run the linter again, you dont need to do the whole setup again. Do this:
+Then if you want to run the linter again, you dont need to run pipenv install. Do this:
 
 ```
-# activate your venv
-source venv/bin/activate
-
-# and run the linter
+# activate pipenv environment and run the linter
+pipenv shell
 python lint.py
 
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,0 @@
-python-frontmatter==0.4.5
-youtube-dl==2020.3.8
-fire==0.3.0


### PR DESCRIPTION
Related issues: [https://github.com/Umuzi-org/ACN-syllabus/issues/25]

## Description:

What are you up to? Fill us in :)
- upgrading to `pipenv` so that user need not create and run a python venv first in order to run the linter but can use pipenv instead.
- The readme file is updated with new instructions on how to run linter in pipenv
- I used pipenv and the required python version is 3.8 
## I solemnly swear that:

- [x] I ran the hugo server and looked at my changed in the browser with my own eyes
- [x] I ran the linter and there were no errors
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
