### PR TITLE
minot changes to ncit syllabuses and one content item

### DIFF
--- a/content/national-qualifications-framework/ncit/assessments/presentation-slides/_index.md
+++ b/content/national-qualifications-framework/ncit/assessments/presentation-slides/_index.md
@@ -18,7 +18,7 @@ title: 'NCIT assessment: Presentation Slides'
 
 Submit the final version of your presentation slides from your design thinking sprint to fulfill the presentation requirements.
 
-Ensure this document meets the standards and criteria in {{% contentlink path="national-qualifications-framework/ncit/content//presenting-your-findings" %}}
+Ensure this document meets the standards and criteria in {{% contentlink path="national-qualifications-framework/ncit/content/presenting-your-findings" %}}
 
 It should be labeled like: FirstName LastName - Research Notes
 

--- a/content/syllabuses/ncit-java.md
+++ b/content/syllabuses/ncit-java.md
@@ -11,8 +11,11 @@ title: NCIT - Java
 - {{% contentlink path="national-qualifications-framework/ncit/assessments/constructive-feedback" %}}
 - {{% contentlink path="national-qualifications-framework/ncit/assessments/object-oriented-programming" flavour="java" %}}
 - {{% contentlink path="national-qualifications-framework/ncit/assessments/conducting-research-and-user-interviews" %}}
+- {{% contentlink path="national-qualifications-framework/ncit/assessments/research-documnet" %}}
 - {{% contentlink path="national-qualifications-framework/ncit/assessments/presenting-your-findings" %}}
+- {{% contentlink path="national-qualifications-framework/ncit/assessments/presentation-slides" %}}
 - {{% contentlink path="national-qualifications-framework/ncit/assessments/write-a-report" %}}
+- {{% contentlink path="national-qualifications-framework/ncit/assessments/technical-report" %}}
 - {{% contentlink path="national-qualifications-framework/ncit/assessments/database-development" %}}
 - {{% contentlink path="national-qualifications-framework/ncit/assessments/search-and-sort-techniques" %}}
 - {{% contentlink path="national-qualifications-framework/ncit/assessments/building-an-online-business" %}}

--- a/content/syllabuses/ncit-javascript.md
+++ b/content/syllabuses/ncit-javascript.md
@@ -11,8 +11,11 @@ title: NCIT - JavaScript
 - {{% contentlink path="national-qualifications-framework/ncit/assessments/constructive-feedback" %}}
 - {{% contentlink path="national-qualifications-framework/ncit/assessments/object-oriented-programming" flavour="javascript" %}}
 - {{% contentlink path="national-qualifications-framework/ncit/assessments/conducting-research-and-user-interviews" %}}
+- {{% contentlink path="national-qualifications-framework/ncit/assessments/research-documnet" %}}
 - {{% contentlink path="national-qualifications-framework/ncit/assessments/presenting-your-findings" %}}
+- {{% contentlink path="national-qualifications-framework/ncit/assessments/presentation-slides" %}}
 - {{% contentlink path="national-qualifications-framework/ncit/assessments/write-a-report" %}}
+- {{% contentlink path="national-qualifications-framework/ncit/assessments/technical-report" %}}
 - {{% contentlink path="national-qualifications-framework/ncit/assessments/database-development" %}}
 - {{% contentlink path="national-qualifications-framework/ncit/assessments/search-and-sort-techniques" %}}
 - {{% contentlink path="national-qualifications-framework/ncit/assessments/building-an-online-business" %}}

--- a/content/syllabuses/ncit-python.md
+++ b/content/syllabuses/ncit-python.md
@@ -11,8 +11,11 @@ title: NCIT - Python
 - {{% contentlink path="national-qualifications-framework/ncit/assessments/constructive-feedback" %}}
 - {{% contentlink path="national-qualifications-framework/ncit/assessments/object-oriented-programming" flavour="python" %}}
 - {{% contentlink path="national-qualifications-framework/ncit/assessments/conducting-research-and-user-interviews" %}}
+- {{% contentlink path="national-qualifications-framework/ncit/assessments/research-documnet" %}}
 - {{% contentlink path="national-qualifications-framework/ncit/assessments/presenting-your-findings" %}}
+- {{% contentlink path="national-qualifications-framework/ncit/assessments/presentation-slides" %}}
 - {{% contentlink path="national-qualifications-framework/ncit/assessments/write-a-report" %}}
+- {{% contentlink path="national-qualifications-framework/ncit/assessments/technical-report" %}}
 - {{% contentlink path="national-qualifications-framework/ncit/assessments/database-development" %}}
 - {{% contentlink path="national-qualifications-framework/ncit/assessments/search-and-sort-techniques" %}}
 - {{% contentlink path="national-qualifications-framework/ncit/assessments/building-an-online-business" %}}


### PR DESCRIPTION
Related issues: [please specify]

## Description:

Minor chenges to the NCIT Syllabuses:

Corrected a link in content/national-qualifications-framework/ncit/assessments/presentation-slides/_index.md

Added the below in the appropriate places in the syllabuses:
- {{% contentlink path="national-qualifications-framework/ncit/assessments/research-documnet" %}}
- {{% contentlink path="national-qualifications-framework/ncit/assessments/presentation-slides" %}}
- {{% contentlink path="national-qualifications-framework/ncit/assessments/technical-report" %}}

## I solemnly swear that:

- [x] I ran the hugo server and looked at my changed in the browser with my own eyes
- [ ] I ran the linter and there were no errors
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
