### PR TITLE
add so and ac to ncit

### DIFF
--- a/content/national-qualifications-framework/ncit/content/agile-meetings/_index.md
+++ b/content/national-qualifications-framework/ncit/content/agile-meetings/_index.md
@@ -1,6 +1,36 @@
 ---
 _db_id: 357
 content_type: topic
+ncit_specific_outcomes:
+- assessment_criteria:
+  - The demonstration describes the types of technical meetings and their uses. 
+  - The demonstration identifies leadership styles used in meeting procedures. 
+  - The demonstration identifies decision making processes used in meetings. 
+  - The demonstration describes meeting conventions relevant to the type of meeting chosen. 
+  - The demonstration identifies that the note taker should have technical background knowledge. 
+  outcome: 1
+  title: Demonstrate knowledge of different types of technical practitioners meetings. 
+- assessment_criteria:
+  - The preparation ensures physical arrangements for the meeting is done, relevant to the type of meeting.  
+  - The preparation ensures that meeting outcomes are clear, concise and well documented.  
+  - The preparation ensures that meeting invitations are extended to relevant participants timeously.  
+  - The preparation completes and distribute the meeting agenda and other supporting documentation needed for the type of meeting. 
+  outcome: 2
+  title: Prepare for a technical practitioners meeting. 
+- assessment_criteria:
+  - The chair and members agree on rules and guidelines on behavior. 
+  - The chair applies agreed meeting conventions throughout the meeting, according to the type of meeting and in accordance with  the standing procedures of the organisation(s) involved.
+  - The chair ensures that the published agenda is followed.
+  - The chair provides for active participation by all members to avoid/ minimize conflict.
+  - The chair ensures that meeting topics are prioritised and that discussion times are allocated according to importance, urgency, complexity and agenda. 
+  - The chair ensures that agreed decisions are clear, accurate, includes a time frame for action and are within the mandate of the type of meeting conducted. 
+  outcome: 3
+  title: Chair a technical practitioners meeting. 
+- assessment_criteria:
+  - The follow up ensures minutes of the meeting is produced accurately and in line with the policy of the organisation. 
+  - The follow up communicates agreed records of discussion to interested parties in a format and time frame that meet requirements of the type of meeting and of the organisation(s) involved. 
+  outcome: 4
+  title: Conduct post meeting follow up for a technical meeting. 
 ncit_standards:
 - 114051
 prerequisites:

--- a/content/national-qualifications-framework/ncit/content/agile-project-management/_index.md
+++ b/content/national-qualifications-framework/ncit/content/agile-project-management/_index.md
@@ -1,6 +1,28 @@
 ---
 _db_id: 370
 content_type: topic
+ncit_specific_outcomes:
+- assessment_criteria:
+  - The demonstration identifies different parts of a cost/benefit analysis. 
+  - The demonstration explains the purpose of the different parts of a cost/benefit analysis. 
+  outcome: 1
+  title: Demonstrate the ability to interpret given cost/benefit analysis documentation. 
+- assessment_criteria:
+  - The time estimate is based on a breakdown of the component in the logical parts for estimating. 
+  - The time estimate is based on an understanding that the estimate should include the implementation/testing of interfaces to other components where applicable. 
+  outcome: 2
+  title: Prepare a time estimate for an element of work. 
+- assessment_criteria:
+  - The cost estimate is based on a breakdown of the component in the logical parts for estimating. 
+  - The cost estimate is based on an understanding that the estimate should include the implementation/testing of interfaces to other components where applicable. 
+  - The cost estimate demonstrates an understanding that being assisted by other resources or people could escalate the costs. 
+  outcome: 3
+  title: Prepare a cost estimate for an element of work.  
+- assessment_criteria:
+  - The demonstration confirms the understanding that an element delivered is often a subset of a bigger deliverable. 
+  - The demonstration explains the affect of late delivery on other related components. 
+  outcome: 4
+  title: Demonstrate an understanding of the affect of late delivery of an element of work. 
 ncit_standards:
 - 114059
 ready: true

--- a/content/national-qualifications-framework/ncit/content/analytics-surveys-and-reports/_index.md
+++ b/content/national-qualifications-framework/ncit/content/analytics-surveys-and-reports/_index.md
@@ -1,6 +1,26 @@
 ---
 _db_id: 372
 content_type: topic
+ncit_specific_outcomes:
+- assessment_criteria:
+  - The explanation identifies the various types of inputs and outputs. 
+  - The explanation distinguishes between appearance and the underlying structure and processes. 
+  - The explanation identifies the purpose of user involvement in creating the designs. 
+  - The explanation compares online computer functions with manual forms and offline data entry. 
+  - The explanation includes a discussion of input and output that compares graphical input and output functions with text based input and output functions. 
+  outcome: 1
+  title: Explain the principles of computer input and output design. 
+- assessment_criteria:
+  - The design meets the specification for the function. 
+  - The design can be implemented in the specified computer environment. 
+  - The design conforms to an industry recommended format for the function. 
+  outcome: 2
+  title: Design computer input and output functions. 
+- assessment_criteria:
+  - The creation ensures that the function format corresponds to the design. 
+  - The creation ensures that the function behaviour corresponds to the design. 
+  outcome: 3
+  title: Create computer input and output functions. 
 ncit_standards:
 - 115365
 prerequisites:

--- a/content/national-qualifications-framework/ncit/content/building-an-online-business/_index.md
+++ b/content/national-qualifications-framework/ncit/content/building-an-online-business/_index.md
@@ -1,6 +1,30 @@
 ---
 _db_id: 360
 content_type: topic
+ncit_specific_outcomes:
+- assessment_criteria:
+  - The identification lists marketing options which are relevant to the web site 
+  - The identification describes how the marketing options could be used to enhance the web site 
+  outcome: 1
+  title: Identify various marketing options for use within e-Commerce web sites. 
+- assessment_criteria:
+  - The explanation identifies legal issues concerning e-Commerce web sites 
+  - The explanation outlines how these legal issues should be incorporated when building the web site 
+  - The explanation ensures that all relevant legal issues have been addressed when implementing the web site
+  outcome: 2
+  title: Explain the legal issues concerning the building of an e-Commerce web site.  
+- assessment_criteria:
+  - Identify possible service providers for hosting the web site 
+  - Identify the costs involved in order to host the web site
+  - Understand contractual agreements for hosting the web site 
+  outcome: 3
+  title: Demonstrate an understanding of hosting arrangements for an e-Commerce web site. 
+- assessment_criteria:
+  - The provision ensures that a "help facility" is available on the web site 
+  - The provision ensures that any technical difficulties experienced on the web site, can be resolved timeously and with ease 
+  - The provision ensures that telephonic or online (or similar ) assistance is available in the event of difficulties being experienced. 
+  outcome: 4
+  title: Demonstrate an understanding of providing support for an e-Commerce web site. 
 ncit_standards:
 - 115385
 prerequisites:

--- a/content/national-qualifications-framework/ncit/content/business-and-technology/_index.md
+++ b/content/national-qualifications-framework/ncit/content/business-and-technology/_index.md
@@ -1,6 +1,26 @@
 ---
 _db_id: 364
 content_type: topic
+ncit_specific_outcomes:
+- assessment_criteria:
+  - The description distinguishes types of business organisations. 
+  - The description outlines the common objectives within which businesses operate.
+  - The description outlines the environment within which businesses operate. 
+  outcome: 1
+  title: Describe fundamental business concepts. 
+- assessment_criteria:
+  - The description defines the concept of a system.
+  - The explanation outlines the functions of computer applications in business. 
+  - The explanation illustrates the effects of IT on business systems. 
+  outcome: 3
+  title: Explain how IT can be used in business. 
+- assessment_criteria:
+  - The explanation distinguishes data and information.
+  - The explanation outlines the role of information in decision making.
+  - The explanation identifies the main threats to data security and integrity. 
+  - The explanation identifies the sub-systems that make up a business and the information needs associated with each sub-system. 
+  outcome: 4
+  title: Explain the relationship between a business and its information needs. 
 ncit_standards:
 - 114050
 ready: false

--- a/content/national-qualifications-framework/ncit/content/conducting-research-and-user-interviews/_index.md
+++ b/content/national-qualifications-framework/ncit/content/conducting-research-and-user-interviews/_index.md
@@ -1,6 +1,58 @@
 ---
 _db_id: 368
 content_type: topic
+ncit_specific_outcomes:
+- assessment_criteria:
+  - The plan identifies the topic, objectives, and scope of the research. 
+  - The plan identifies the time to be taken for the research, the research methods to be used, and the sources of information to be used. 
+  - The plan identifies the target audience, presentation methods, and the computer applications to be used for the analysis of data and the presentation of the results of the research. 
+  outcome: 1
+  title: Plan the research of a computer topic. 
+- assessment_criteria:
+  - The research conducted accumulates data according to the research plan. 
+  - The research conducted provides data analysis with conclusions. 
+  - The description of the analysis methods allows the validity of the analysis to be assessed. 
+  - Research progress is indicated at intervals by reports, according to the research plan. 
+  - The research conducted uses a computer application to analyse the research data. 
+  outcome: 2
+  title: Conduct research of a computer topic using computer technology.
+- assessment_criteria:
+  - The presentation is made using the computer application identified in the research plan. 
+  - The presentation communicates summarised research data and conclusions to the target audience. 
+  outcome: 3
+  title: Present the results of research of a computer topic using computer technology 
+
+- assessment_criteria:
+  - The interviewee reports that he or she has understood the interview objectives. 
+  - The interviewee reports that he or she has understood the interview questions. 
+  - The interview provides answers that meet interview objectives. 
+  - The presentation of the interview is appropriate to the interviewee. 
+  outcome: 1
+  title: Design and conduct an interview for gathering information for computer system development. 
+- assessment_criteria:
+  - The respondents report that they understand the questionnaire objectives. 
+  - The respondents report that they understand the questions. 
+  - The questionnaire responses provide answers that meet questionnaire objectives. 
+  - The presentation of the questionnaire is appropriate to the target population. 
+  - A summary of questionnaire responses, and a comparison with expected responses, allows summary statements to be made about the population sample. 
+  outcome: 2
+  title: Design and perform an analysis of the results from a questionnaire for gathering information.   
+- assessment_criteria:
+  - Research notes identify data that meet the specified information requirements using an industry recommended format.
+  - Research notes identify the characteristics of the data and the relationships between data items. 
+  - Research notes identifying data items facilitate access to those data items.  
+  outcome: 3
+  title: Gather data from documents for computer system development. 
+- assessment_criteria:
+  - A record of the behaviour identifies events that meet the specified information requirements, and outlines those events. 
+  - A report about the observation compares the outcome of the observation with the observation objectives. 
+  outcome: 4
+  title: Observe a person's behaviour for gathering information for computer system development.
+- assessment_criteria:
+  - The comparison identifies agreement and differences between the information gathered from different techniques. 
+  - Differences are resolved and justified by reviewing the information gathering techniques. 
+  outcome: 5
+  title: Consolidate the information gathered via different techniques. 
 ncit_standards:
 - 114076
 - 115358

--- a/content/national-qualifications-framework/ncit/content/constructive-feedback/_index.md
+++ b/content/national-qualifications-framework/ncit/content/constructive-feedback/_index.md
@@ -1,6 +1,32 @@
 ---
 _db_id: 359
 content_type: topic
+ncit_specific_outcomes:
+- assessment_criteria:
+  - The provision is selected in terms of type and channel 
+  - The provision ensures that the language, content and tone of feedback fit the situation, the occasion, the subject matter and the audience 
+  - The provision describes the behavior or event which is the focus of feedback, in neutral terms, with the absence of reference to character or personality of the recipient
+  - The provision identifies legal and ethical requirements that impact on the time and place where feedback is provided 
+  - The provision ensures that the content of the message meets the objectives set for providing feedback
+  - The provision ensures that constructive feedback incorporates listening, open questions, paraphrasing and responding to receiver reactions 
+  outcome: 1
+  title: Provide constructive feedback. 
+- assessment_criteria:
+  - The analysis identifies issues related to providing feedback in terms of context/ situation 
+  - The analysis identifies the purpose and/ or outcomes for specific feedback contexts/ situations
+  - The analysis identifies consequences and/ or anticipated reactions for specific feedback contexts/ situations
+  - The analysis ensures that the content and tone of feedback fit the situation, the occasion, the subject matter and the audience
+  - The analysis identifies the legal and organisational requirements that impact on the type and manner of feedback provided  
+  outcome: 2
+  title: Analyse feedback contexts and/ or situations. 
+- assessment_criteria:
+  - The response ensures that the medium, language, content and tone fits the situation, the occasion, the matter and the audience
+  - The response clarifies feedback received, in terms of the objectives and issues raised 
+  - The response evaluates feedback received, in terms of its applicability to the objectives and issues raised
+  - The response incorporates identifying options and/ or strategies for further action
+  - The response evaluated the outcome of feedback to determine if the objectives are met, or require further action 
+  outcome: 3
+  title: Respond constructively to feedback. 
 ncit_standards:
 - 115431
 ready: true

--- a/content/national-qualifications-framework/ncit/content/database-development/_index.md
+++ b/content/national-qualifications-framework/ncit/content/database-development/_index.md
@@ -1,6 +1,69 @@
 ---
 _db_id: 373
 content_type: topic
+ncit_specific_outcomes:
+- assessment_criteria:
+  - The review identifies and explains the feasibility of the requirements. 
+  - The review identifies the database access objectives and critical performance factors. 
+  - The review estimates the development effort required so that the cost may be estimated. 
+  - A review procedure is adopted, which ensures that the outcomes meet the database access requirements. 
+  outcome: 1
+  title: Review the requirements for database access for a computer application using SQL.
+- assessment_criteria:
+  - The design implements user requirements. 
+  - The design of the database structure resembles the output from the data analysis. 
+  - The structure of each table in the database adheres to the third normal form. 
+  - The methods of accessing the data are identified. 
+  - The key relationships between the tables within the database are identified. 
+  - The data types for primary and foreign keys are consistent throughout the database. 
+  outcome: 2
+  title: Design database access for a computer application using SQL.
+- assessment_criteria:
+  - The program code implements the program design. 
+  - The program code uses language constructs that facilitate the understanding of the code. 
+  - The program code utilises the optimising features of the languages being used. 
+  - The program code uses language instructions that facilitate the understanding op the code. 
+  - The program code uses language constructs that facilitate the understanding of the code. 
+  - Tables joined in a query are essential to its outcome. 
+  - The program code uses constructs that preserve the integrity of the data being accessed by multiple users and processes. 
+  - Global data sharing is minimised to enable weak coupling, and modules exhibit functional cohesion.
+  outcome: 3
+  title: Write program code for database access for a computer application using SQL.
+- assessment_criteria:
+  - The testing checks all program logic paths. 
+  - The testing corrects program code to eliminate errors identified through testing. 
+  - The testing verifies that the database access functions in the required environment. 
+  - The testing verifies that the database access performs according to the design requirements. 
+  - The testing verifies that the database access functions according to the design requirements. 
+  outcome: 4
+  title: Test programs for a computer application that accesses a database using SQL. 
+- assessment_criteria:
+  - The documentation enhances the understanding of the program code. 
+  - The documentation complements the self-documenting attributes of the program code. 
+  outcome: 5
+  title: Document programs for a computer application that accesses a database using SQL. 
+
+- assessment_criteria:
+  - The description identifies the problem they represent and includes examples. 
+  - The description outlines ways which database management systems address the issues. 
+  outcome: 1
+  title: Describe data management issues and how it is addressed by a DBMS.
+- assessment_criteria:
+  - The description identifies the purpose of each feature. 
+  - The description identifies the way in which each feature contributes to the solution of data management issues. 
+  outcome: 2
+  title: Describe commonly implemented features of commercial database management systems. 
+- assessment_criteria:
+  - The description describes characteristics of the DBMS-type. 
+  - The description gives examples of the use of the DBMS-type. 
+  outcome: 3
+  title: Describe different type of DBMS`s. 
+- assessment_criteria:
+  - The review identifies the features and limitations of the tools. 
+  - The review outlines the interaction between the tools and the database. 
+  - The review is based upon use of the tools. 
+  outcome: 4
+  title: Review DBMS end-user tools. 
 flavours:
 - none
 ncit_standards:

--- a/content/national-qualifications-framework/ncit/content/ethics-and-professionalism/_index.md
+++ b/content/national-qualifications-framework/ncit/content/ethics-and-professionalism/_index.md
@@ -1,6 +1,24 @@
 ---
 _db_id: 369
 content_type: topic
+ncit_specific_outcomes:
+- assessment_criteria:
+  - The description identifies acceptable and unacceptable professional practices found in the computer industry.
+  - The description identifies known professional bodies in South Africa.
+  - A short description of each named professional body is provided. 
+  outcome: 1
+  title: Describe professionalism for the computer industry in South Africa. 
+- assessment_criteria:
+  - The description identifies the codes of practice for the IT industry in South Africa.
+  - The description provides a brief explanation of the codes of practice identified. 
+  outcome: 2
+  title: Describe the codes of practice for professionalism in the IT industry in South Africa.   
+- assessment_criteria:
+  - The description confirms that the computer industry supports equality of opportunity.
+  - The description confirms the understanding that the computer industry is against computer software piracy.
+  - The description identifies ways in which piracy is addressed in South Africa. 
+  outcome: 3
+  title: Describe the code of ethics in the computer industry in South Africa. 
 ncit_standards:
 - 114055
 ready: true

--- a/content/national-qualifications-framework/ncit/content/managing-the-software-development-process/_index.md
+++ b/content/national-qualifications-framework/ncit/content/managing-the-software-development-process/_index.md
@@ -1,6 +1,48 @@
 ---
 _db_id: 374
 content_type: topic
+ncit_specific_outcomes:
+- assessment_criteria:
+  - The plan proposes a description of the problem to be solved by the development of the computer program that is understandable by an end-user and meets the given specification. 
+  - The plan integrate the research of problems in term of data and functions 
+  - The plan includes an evaluation of the viability of developing a computer program to solve the problem identified and compares the costs of developing the program with the benefits to be obtained from the program. 
+  - At least two different possible solutions
+  - The plan concludes by choosing the best solution and documenting the program features that will contain the capabilities and constraints to meet the defined problem. 
+  outcome: 1
+  title: Interpret a given specification to plan a computer program solution. 
+- assessment_criteria:
+  - The design incorporates development of appropriate design documentstion and is desk-checked.
+  - The design of the program includes program structure components.
+  - The design of the program includes program logical flow components.
+  - The design of the program includes data structures and access method components. 
+  outcome: 2
+  title: Design a computer program to meet a business requirement.  
+- assessment_criteria:
+  - The creation includes coding from design documents, to meet the design specifications
+  - Names created in the program describe the purpose of the items named
+  - According to industry or company standards for the language chosen
+  - The creation includes conformance with the design documentation, and differences are documented with reasons for deviations 
+  outcome: 3
+  title: Create a computer program that implements the design. 
+- assessment_criteria:
+  - The testing includes assessment of the need to develop a testing program to assist with stress testing
+  - The testing includes the planning, developing and implementing a test strategy that is appropriate for the type of program being tested.
+  - The testing includes the recording of test results that allow for the identification and validation of test outcomes. 
+  outcome: 4
+  title: Test a computer program against the business requirements. 
+- assessment_criteria:
+  - The implementation involves checking the program for compliance with user expectations and any other applicable factors 
+  - The implementation involves training of users to enable them to use the software to their requirements
+  - The implementation involves planning of installation of the program that minimises disruption to the user 
+  outcome: 5
+  title: Implement the program to meet business requirements. 
+- assessment_criteria:
+  - The documentation includes annotation of the program with a description of program purpose and design specifics. 
+  - The documentation includes the layout of the program code including indentation and other acceptable industry standards 
+  - The documentation includes full internal and external documentation, with a level of detail that enables other programmers to analyse the program
+  - The documentation reflects the tested and implemented program, including changes made during testing of the program 
+  outcome: 6
+  title: Document the program according to industry standards. 
 ncit_standards:
 - 115392
 prerequisites:

--- a/content/national-qualifications-framework/ncit/content/object-oriented-programming/_index.md
+++ b/content/national-qualifications-framework/ncit/content/object-oriented-programming/_index.md
@@ -1,6 +1,36 @@
 ---
 _db_id: 358
 content_type: topic
+ncit_specific_outcomes:
+- assessment_criteria:
+  - The demonstration identifies situations from real-life problems where inheritance is applicable. 
+  - The demonstration implements inheritance in OOP language. 
+  outcome: 1
+  title: Demonstrate an understanding of inheritance in object oriented programming (OOP)
+- assessment_criteria:
+  - The demonstration identifies situations from real-life problems where polymorphism is applicable. 
+  - The demonstration implements polymorphism in OOP language.
+  outcome: 2
+  title: Demonstrate an understanding of polymorphism in object oriented programming (OOP).  
+- assessment_criteria:
+  - The analysis describes basic UML standards to identify classes.
+  - The analysis identifies base and sub-classes in a problem situation.
+  - The analysis identifies polymorphism in a problem situation.
+  - The analysis identifies inter-class communication in a problem situation. 
+  outcome: 3
+  title: Analyse problem situations to plan an OOP implementation. 
+- assessment_criteria:
+  - Describe the purpose of abstract classes in the optimisation of re-usability.
+  - Describe wrapper classes and their need in OOP design.
+  - Implement abstract and wrapper classes in OOP language. 
+  outcome: 4
+  title: Use abstract classes to optimise re-usability. 
+- assessment_criteria:
+  - Describes different design patterns.
+  - Explain the advantages of using the chosen design pattern.
+  - Implement the chosen design pattern in an OOP language. 
+  outcome: 5
+  title: Use basic design patterns to optimise re-usability. 
 flavours:
 - any_language
 ncit_standards:

--- a/content/national-qualifications-framework/ncit/content/presenting-your-findings/_index.md
+++ b/content/national-qualifications-framework/ncit/content/presenting-your-findings/_index.md
@@ -1,6 +1,31 @@
 ---
 _db_id: 375
 content_type: topic
+ncit_specific_outcomes:
+- assessment_criteria:
+  - 
+  outcome: 1
+  title: Research and plan the content of the presentation in relation to the target audience.
+- assessment_criteria:
+  - 
+  outcome: 2
+  title: Prepare and organize presentation material.  
+- assessment_criteria:
+  - 
+  outcome: 3
+  title: Apply technical presentation techniques with or without technical equipment.
+- assessment_criteria:
+  - 
+  outcome: 4
+  title: Display optimal presentation skills.
+- assessment_criteria:
+  - 
+  outcome: 5
+  title: Perform self-monitoring and adapt the presentation.
+- assessment_criteria:
+  - 
+  outcome: 6
+  title: 
 ncit_standards:
 - 13925
 prerequisites:

--- a/content/national-qualifications-framework/ncit/content/pseudocode-and-documentation/_index.md
+++ b/content/national-qualifications-framework/ncit/content/pseudocode-and-documentation/_index.md
@@ -1,6 +1,23 @@
 ---
 _db_id: 363
 content_type: topic
+ncit_specific_outcomes:
+- assessment_criteria:
+  - The documentation design covers the format of the documents in line with industry conventions.
+  - The documentation plan covers full program documentation components. 
+  outcome: 1
+  title: Plan and design documentation for a computer program to agreed standards. 
+- assessment_criteria:
+  - The documentation is created according to the design created in specific outcome 'Plan and design documentation for a computer program to agreed standards'.
+  - The documentation components created are created according to the plan specified in specific outcome 'Plan and design documentation for a computer program to agreed standards'.
+  - The documentation created is structured sensibly, defining how program specifications have been met. 
+  outcome: 2
+  title: Create documentation for a computer program to agreed standards. 
+- assessment_criteria:
+  - The review identifies if documentation was created according to the design created in specific outcome 'Plan and design documentation for a computer program to agreed standards'.
+  - The review identifies if documentation was created consistent with the computer program being documented. 
+  outcome: 3
+  title: Review documentation for a computer program for completeness. 
 ncit_standards:
 - 115388
 prerequisites:

--- a/content/national-qualifications-framework/ncit/content/search-and-sort-techniques/_index.md
+++ b/content/national-qualifications-framework/ncit/content/search-and-sort-techniques/_index.md
@@ -1,6 +1,24 @@
 ---
 _db_id: 376
 content_type: topic
+ncit_specific_outcomes:
+- assessment_criteria:
+  - The demonstration identifies different abstract data types used in computer programming.
+  - The demonstration identifies different data structures used to store abstract data types in a computer. 
+  outcome: 1
+  title: Demonstrate an understanding of how abstract data types are stored on computers. 
+- assessment_criteria:
+  - The demonstration identifies different types of sort techniques
+  - The demonstration explains the working of different types of sort techniques
+  - The demonstration explains typical problems found with sorting of data 
+  outcome: 2
+  title: Demonstrate an understanding of sort techniques used to sort data held in data structures.  
+- assessment_criteria:
+  - The demonstration identifies different types of search techniques
+  - The demonstration explains the working of different types of search techniques
+  - The demonstration explains typical problems found with searching of data 
+  outcome: 3
+  title: Demonstrate an understanding of search techniques. 
 ncit_standards:
 - 115373
 prerequisites:

--- a/content/national-qualifications-framework/ncit/content/test-driven-development/_index.md
+++ b/content/national-qualifications-framework/ncit/content/test-driven-development/_index.md
@@ -1,6 +1,45 @@
 ---
 _db_id: 371
 content_type: topic
+ncit_specific_outcomes:
+- assessment_criteria:
+  - The explanation covers the difference between an error and a mistake. 
+  - The explanation covers the errors found in data entry via computer input devices. 
+  - The explanation identifies sources of induced errors in calculations. 
+  outcome: 1
+  title: Explain different errors found in the computer programming environment. 
+- assessment_criteria:
+  - The demonstration explains overflow errors found in computers. 
+  - The demonstration explains underflow errors found in computers. 
+  - The demonstration explains conversion errors found in computers. 
+  - The demonstration explains errors found in computers because of advancement in processor word-sizes. 
+  outcome: 2
+  title: Demonstrate how calculation errors are induced in the computer. 
+- assessment_criteria:
+  - The demonstration explains how mistakes can be minimised. 
+  - The demonstration explains how errors can be minimised. 
+  outcome: 3
+  title: Demonstrate how mistakes and computer errors can be minimised. 
+
+- assessment_criteria:
+  - The testing executes operational steps identified in the test plan. 
+  - The testing uses input data as specified in the test plan. 
+  - The testing outlines deviations from the test plan, with explanations. 
+  - The testing follows the standards and procedures specified in the test plan for testing and re-testing. 
+  outcome: 1
+  title: Test a computer program against given specifications according to test plans. 
+- assessment_criteria:
+  - The records are provided for all tests executed. 
+  - The records identify variations from expected test results and gives reason where available. 
+  - The recorded results are reproduced if the tests are repeated under the same conditions. 
+  - The recorded results are recorded in a way that allows the results to be reviewed. 
+  outcome: 2
+  title: Record the results from testing a computer program. 
+- assessment_criteria:
+  - The review allows improvements to be made to the application testing process.
+  - The review follows organisation policy and procedures. 
+  outcome: 3
+  title: Review the testing process for a computer program against organisation policy and procedures.
 flavours:
 - any_language
 ncit_standards:

--- a/content/national-qualifications-framework/ncit/content/thinking-like-a-machine/_index.md
+++ b/content/national-qualifications-framework/ncit/content/thinking-like-a-machine/_index.md
@@ -1,6 +1,34 @@
 ---
 _db_id: 639
 content_type: topic
+ncit_specific_outcomes:
+- assessment_criteria:
+  - The description identifies the different problem solving techniques.
+  - The description identifies situations where specific problem solving techniques would be more suitable than others
+  - The description utilises the top-down problem solving approach in real life problems known to the learner.
+  - The description allows for the practice of problem breakdown in picture drawing applications. 
+  outcome: 1
+  title: Describe different approaches to problem solving.
+- assessment_criteria:
+  - Usage describes the logical operators by drawing truth tables
+  - Usage provides examples of problem situations where a specific operator can be used.
+  - Usage identifies which of the operators should be used to represent given situations.
+  - Usage combines different operators to form Boolean expressions by setting up truth tables. 
+  outcome: 2
+  title: Use logical operators in descriptions of rules and relationships in a problem situation. 
+- assessment_criteria:
+  - The simplification describes the rules of Boolean algebra.
+  - The simplification uses the Boolean algebra rules to simplify given expressions. 
+  - The simplification uses Karnaugh maps to represent Boolean expressions.
+  - The simplification involves writing down the simplified expression from the map. 
+  outcome: 3
+  title: Simplify Boolean expressions with Boolean algebra and Karnaugh maps. 
+- assessment_criteria:
+  - The description identifies the common causes of errors
+  - The description identifies error isolation techniques. 
+  - The description identifies various testing techniques.  
+  outcome: 4
+  title: Describe the basic concepts of error detection. 
 flavours:
 - any_language
 ncit_standards:

--- a/content/national-qualifications-framework/ncit/content/version-control/_index.md
+++ b/content/national-qualifications-framework/ncit/content/version-control/_index.md
@@ -1,6 +1,18 @@
 ---
 _db_id: 366
 content_type: topic
+ncit_specific_outcomes:
+- assessment_criteria:
+  - The location ensures that the correct source file is identified. 
+  - The location ensures that the correct versions of additional files associated with the software development source files are identified. 
+  outcome: 1
+  title: Locate software development source files. 
+- assessment_criteria:
+  - Retrieval and updating of the source file is in accordance with organisation procedures. 
+  - Retrieval protects source files from loss while updates are in progress. 
+  - Retrieval prevents source files from being updated simultaneously by two or more people. 
+  outcome: 2
+  title: Retrieve software development source files for update purposes. 
 flavours:
 - any_language
 ncit_standards:

--- a/content/national-qualifications-framework/ncit/content/web-design-for-business/_index.md
+++ b/content/national-qualifications-framework/ncit/content/web-design-for-business/_index.md
@@ -1,6 +1,18 @@
 ---
 _db_id: 367
 content_type: topic
+ncit_specific_outcomes:
+- assessment_criteria:
+  - The discussion outlines the primary basis on which web sites are designed 
+  - The discussion identifies different uses of the Internet as business tool 
+  outcome: 1
+  title: Discuss the use of web sites in business. 
+- assessment_criteria:
+  - The demonstration identifies the basic concepts to apply to design and production of the web pages 
+  - The demonstration explains the use of techniques to make the web site accessible and popular 
+  - The demonstration recognises the need to protect a web site 
+  outcome: 2
+  title: Demonstrate an understanding of the basic concepts of web-site design for business use. 
 ncit_standards:
 - 115374
 prerequisites:

--- a/content/national-qualifications-framework/ncit/content/write-a-report/_index.md
+++ b/content/national-qualifications-framework/ncit/content/write-a-report/_index.md
@@ -1,6 +1,36 @@
 ---
 _db_id: 355
 content_type: topic
+ncit_specific_outcomes:
+- assessment_criteria:
+  - The purpose of the report is determined and clearly defined.  
+  - All facts, which have a bearing on the report are ascertained. 
+  - The correct equipment and/or tools required to ascertain the facts is selected. 
+  - Those facts to be presented in the report are selected and put in the order of presentation. 
+  - The order of presentation is logical. 
+  - The consequences of providing incorrect information are listed and explained. 
+  outcome: 1
+  title: Collect information for writing the report. 
+- assessment_criteria:
+  - The order of presentation of the facts is determined. 
+  - Appropriate headings are selected for the report. 
+  - Only those facts, which are necessary for the report to achieve its purpose are selected. 
+  - All facts and figures are put together in a way the reader will be able to understand. 
+  outcome: 2
+  title: Plan the writing of the report. 
+- assessment_criteria:
+  - The wording and phraseology is appropriate for the recipient. 
+  - The layout of the report is correct. 
+  - The report contains the correct headings. 
+  - The report is unbiased and factual. 
+  - The report is readable. 
+  outcome: 3
+  title: Write the report. 
+- assessment_criteria:
+  - The report is checked to ensure it is clear, concise, complete and correct. 
+  - The report is written or typed. 
+  outcome: 4
+  title: Revise the report. 
 ncit_standards:
 - 116389
 prerequisites:


### PR DESCRIPTION
Related issues: [please specify]

## Description: Added Specific outcomes and assessment criteria to ncit topics

A couple of things to note:

1. Some topics are linked to 2 unit standards, in this case I added the SO and AC for both with the lower unit standard at the top, this matches the order the unit standards are listed in.

2. The unit standard for : content/national-qualifications-framework/ncit/presenting-your-findings/_index.md is formatted differently from all the others and the assessment criteria are unclear see: https://allqs.saqa.org.za/showUnitStandard.php?id=13925

What are you up to? Fill us in :)

## I solemnly swear that:

- [x] I ran the hugo server and looked at my changed in the browser with my own eyes
- [ ] I ran the linter and there were no errors
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
