### PR TITLE
Added spaces before colon to fix links

### DIFF
--- a/content/topics/python-specific/mongodb/_index.md
+++ b/content/topics/python-specific/mongodb/_index.md
@@ -5,6 +5,6 @@ ready: true
 title: MongoDB and Python
 ---
 
-- https://www.mongodb.com/blog/post/getting-started-with-python-and-mongodb  : The official "getting started" guide
-- https://docs.mongodb.com/manual/tutorial/getting-started/  : something a bit more in depth
-- https://realpython.com/introduction-to-mongodb-and-python/  : a nice tutorial from the folks at RealPython
+- [The official "getting started" guide](https://www.mongodb.com/blog/post/getting-started-with-python-and-mongodb)
+- [Something a bit more in depth](https://docs.mongodb.com/manual/tutorial/getting-started/)
+- [A nice tutorial from the folks at RealPython](https://realpython.com/introduction-to-mongodb-and-python/)

--- a/content/topics/python-specific/mongodb/_index.md
+++ b/content/topics/python-specific/mongodb/_index.md
@@ -5,6 +5,6 @@ ready: true
 title: MongoDB and Python
 ---
 
-- https://www.mongodb.com/blog/post/getting-started-with-python-and-mongodb: The official "getting started" guide
-- https://docs.mongodb.com/manual/tutorial/getting-started/: something a bit more in depth
-- https://realpython.com/introduction-to-mongodb-and-python/: a nice tutorial from the folks at RealPython
+- https://www.mongodb.com/blog/post/getting-started-with-python-and-mongodb  : The official "getting started" guide
+- https://docs.mongodb.com/manual/tutorial/getting-started/  : something a bit more in depth
+- https://realpython.com/introduction-to-mongodb-and-python/  : a nice tutorial from the folks at RealPython


### PR DESCRIPTION
Related issues: [please specify]
The links would return 404 because the colon ':' was rendered into the URL. 

## Description:

What are you up to? Fill us in :)
I only added spaces before the colon. 

## I solemnly swear that:

- [ ] I ran the hugo server and looked at my changed in the browser with my own eyes
- [ ] I ran the linter and there were no errors
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
