### PR TITLE
python-decorators-title-fix

### DIFF
--- a/content/topics/python-specific/decorators-advanced/_index.md
+++ b/content/topics/python-specific/decorators-advanced/_index.md
@@ -8,7 +8,7 @@ ready: true
 tags:
 - python
 - decorators
-title: Python Decorators - Intro
+title: Python Decorators - Advanced
 ---
 
 https://www.codementor.io/@sheena/advanced-use-python-decorators-class-function-du107nxsv

--- a/content/topics/python-specific/decorators-intro/_index.md
+++ b/content/topics/python-specific/decorators-intro/_index.md
@@ -5,7 +5,7 @@ ready: true
 tags:
 - python
 - decorators
-title: Python Decorators
+title: Python Decorators - Intro
 ---
 
 https://www.codementor.io/@sheena/introduction-to-decorators-du107vo5c


### PR DESCRIPTION
Related issues: NONE

## Description:
The python decorators topics are mixed up; currently `Python Decorators - Intro` is showing up as `Python Decorators` on the site and vice versa. So when you click on the `Python Decorators - Intro` link on the site or the card on Tilde it actually takes you to the advanced decorators page.

## I solemnly swear that:

- [x] I ran the hugo server and looked at my changed in the browser with my own eyes
- [x] I ran the linter and there were no errors
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
