### PR TITLE
Removed duplicate resource link

### DIFF
--- a/content/topics/jasmine-spies/_index.md
+++ b/content/topics/jasmine-spies/_index.md
@@ -176,6 +176,5 @@ By default a spy will only report if a call was done without calling through the
 ### References
 
 [An Introduction to Jasmine Unit Testing.]( https://www.freecodecamp.org/news/jasmine-unit-testing-tutorial-4e757c2cbf42/#Understanding%20Spies )  
-[Spy on JavaScript Methods Using the Jasmine Testing Framework]( https://www.htmlgoodies.com/html5/javascript/spy-on-javascript-methods-using-the-jasmine-testing-framework.html )   
-[Spies in Isolation]( https://www.htmlgoodies.com/html5/javascript/spy-on-javascript-methods-using-the-jasmine-testing-framework.html )  
+[Spy on JavaScript Methods Using the Jasmine Testing Framework]( https://www.htmlgoodies.com/html5/javascript/spy-on-javascript-methods-using-the-jasmine-testing-framework.html )  
 [Spying On JavaScript methods using Jasmine]( https://blog.codeship.com/jasmine-spyon/ )


### PR DESCRIPTION
I removed the reference "Spies in Isolation" because it was pointing to the same link as "Spy on JavaScript Methods Using the Jasmine Testing Framework". And I couldn't find the right resource for that reference link.

Related issues: [please specify]

## Description:

What are you up to? Fill us in :)

## I solemnly swear that:

- [x] I ran the hugo server and looked at my changed in the browser with my own eyes
- [x] I ran the linter and there were no errors
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
