### PR TITLE
typo mistake on line 71 "test" must be "text"

### DIFF
--- a/content/projects/tilde/repo-card-tutorial/part-1/_index.md
+++ b/content/projects/tilde/repo-card-tutorial/part-1/_index.md
@@ -68,7 +68,7 @@ I repeat: For now you should not add any reviewers to any of your PRs because we
 
 ### 1. Make a file
 
-Open up your test editor of choice and create a markdown file. This is a plain text file. Name it `important.md`.
+Open up your text editor of choice and create a markdown file. This is a plain text file. Name it `important.md`.
 
 Inside the text file please write a list of everyone you should be adding to your PR as reviewers and why.
 


### PR DESCRIPTION
Students without prior knowledge of text editors might think test editors are real

Related issues: [please specify]

## Description: Typo mistake changes intended meaning of the sentence

What are you up to? Fill us in :)

## I solemnly swear that:

- [x] I ran the hugo server and looked at my changed in the browser with my own eyes
- [x] I ran the linter and there were no errors
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
