### PR TITLE
fix broken link in api basics

### DIFF
--- a/content/topics/apis/basics/_index.md
+++ b/content/topics/apis/basics/_index.md
@@ -20,5 +20,5 @@ You'll also need to know a bit about JSON
 
 The following tools are useful for manually playing with api:
 
-- [curl](https://quickleft.com/blog/command-line-tutorials-curl/)
+- [curl basics](https://web.archive.org/web/20181012061506/https://quickleft.com/blog/command-line-tutorials-curl/) | [official tutorial](https://curl.se/docs/manual.html)
 - [Postman](https://www.getpostman.com/postman)


### PR DESCRIPTION
Related issues: None

## Description:

Replaced broken link with version archived on https://web.archive.org and also added link to official tutorial.

## I solemnly swear that:

- [x] I ran the hugo server and looked at my changed in the browser with my own eyes
- [x] I ran the linter and there were no errors
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
