### PR TITLE
Clearer rephrase

### DIFF
--- a/content/projects/semitone-challenge/gui-part-2/_index.md
+++ b/content/projects/semitone-challenge/gui-part-2/_index.md
@@ -36,7 +36,7 @@ Extend your simple gui with the following behavior:
 1. When the user loads the page for the first time then there should be two notes already displayed on the screen.
 2. Add a button with the text "Reveal answer". If the user clicks on this button then ALL the notes (A, A#, B,...) should be displayed in a div with the id "explanation". The currently selected notes should be highlighted and the final answer should be displayed on the screen.
 3. If the user clicks on the "Get random notes" button then the "explanation" div should be emptied.
-4. If the user submits the correct answer then the "explanation" div should be populated as above. The user should be congratulated just like before
+4. If the user submits the correct answer then the "explanation" div should be populated with the currently selected notes highlighted. The user should be congratulated.
 5. Keep track of how many correct answers the user gets in a row and display this answer on the screen. This is referred to as a streak. Have some pseudocode:
 
 ```


### PR DESCRIPTION
1. The user was never "congratulated before", this only happens when the submit an answer that is correct.
2. There's a lot of confusion with regards to the 2nd and 4th behavior of the game. "As before" in instructions #4 is mistakenly interpreted as "showing the explanation div and final answer", whereas it only means showing the explanation div with highlighted current notes.

Related issues: [please specify]

## Description:

What are you up to? Fill us in :)

## I solemnly swear that:

- [ ] I ran the hugo server and looked at my changed in the browser with my own eyes
- [ ] I ran the linter and there were no errors
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
