### PR TITLE
added tag to technical assessments

### DIFF
--- a/content/specific-skill-success-criteria/basic-data-analysis/_index.md
+++ b/content/specific-skill-success-criteria/basic-data-analysis/_index.md
@@ -2,6 +2,7 @@
 _db_id: 710
 content_type: project
 ready: true
+tags: technical-assessment
 flavours:
 - none
 submission_type: link

--- a/content/specific-skill-success-criteria/classes-and-objects/_index.md
+++ b/content/specific-skill-success-criteria/classes-and-objects/_index.md
@@ -2,6 +2,7 @@
 _db_id: 711
 content_type: project
 ready: true
+tags: technical-assessment
 flavours:
 - any_language
 submission_type: link

--- a/content/specific-skill-success-criteria/for-loops/_index.md
+++ b/content/specific-skill-success-criteria/for-loops/_index.md
@@ -4,6 +4,7 @@ content_type: project
 flavours:
 - any_language
 ready: true
+tags: technical-assessment
 submission_type: link
 title: 'Assessment: For loops'
 ---

--- a/content/specific-skill-success-criteria/functions-and-return/_index.md
+++ b/content/specific-skill-success-criteria/functions-and-return/_index.md
@@ -4,6 +4,7 @@ content_type: project
 flavours:
 - any_language
 ready: true
+tags: technical-assessment
 submission_type: link
 title: 'Assessment: Functions, return statements and printing to the terminal'
 ---


### PR DESCRIPTION
Related issues: NA

## Description:

Added tags to the technical assessments so that they can be excluded from the TeamStatsSerializer as they are clouding the data and making the scrum masters jobs harder

## I solemnly swear that:

- [ ] I ran the hugo server and looked at my changed in the browser with my own eyes
- [ ] I ran the linter and there were no errors
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
