### PR TITLE
Fixing an error on the classes-and-objects assessments instructions

### DIFF
--- a/content/specific-skill-success-criteria/classes-and-objects/_index.md
+++ b/content/specific-skill-success-criteria/classes-and-objects/_index.md
@@ -14,6 +14,16 @@ title: 'Assessment: Classes and objects'
 
 On Tilde you'll notice that this card is asking for a link submission. **Please don't worry about submitting a link**. You will be assessed according to {{% contentlink path="specific-skill-success-criteria/introduction-to-assessments" %}}
 
+
+All students need to provably understand all of the following concepts:  
+- how constructors work
+- construction of multiple class instances:
+  - make many objects of the same class
+  - interact with them and see that they are distinct
+- getters and setters
+- inheritance and overriding and extending methods
+- composition
+
 ## Python
 
 ### Constructors


### PR DESCRIPTION
Related issues: [assessment-classes-and-objects main instructions erroneously removed #431](https://github.com/Umuzi-org/Tilde/issues/431)

## Description:

Fixing an error on the classes-and-objects assessments instructions

## I solemnly swear that:

- [x] I ran the hugo server and looked at my changed in the browser with my own eyes
- [x] I ran the linter and there were no errors
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
