### PR TITLE
updated node tutorial link

### DIFF
--- a/content/topics/js-and-node-specific/node/_index.md
+++ b/content/topics/js-and-node-specific/node/_index.md
@@ -3,15 +3,16 @@ _db_id: 131
 content_type: topic
 ready: true
 tags:
-- node
-- javascript
-- backend
+  - node
+  - javascript
+  - backend
 title: Node
 ---
 
 Wikipedia.org defines Node.js as an open-source, cross-platform and JavaScript runtime environment that executes JavaScript code outside of a browser.
 
 Node.js lets you write JavaScript code that runs on a server. This has many uses:
+
 - Command line utilities and utility scripts.
 - Web app backends that dynamically generate web page html or expose apis.
 
@@ -20,4 +21,4 @@ Here are a few articles to get your head around the concepts:
 - [Server-side website programming first steps](https://developer.mozilla.org/en-US/docs/Learn/Server-side/First_steps): please read all the guides listed under the "Guides" heading.
 - [About Node](https://nodejs.org/en/about/) : try to understand this whole page.
 - [The Node Package Manager](https://docs.npmjs.com/about-packages-and-modules)
-- [Node tutorial](https://www.w3schools.com/nodejs/nodejs_npm.asp) Please work through the whole tutorial. There are all sorts of cool things you can do with this knowledge.
+- [Node tutorial](https://www.w3schools.com/nodejs/default.asp): Please work through the whole tutorial. There are all sorts of cool things you can do with this knowledge.


### PR DESCRIPTION
Related issues: [please specify]

## Description:

The previous link led to the npm part, which is part of the node tutorial, but the instruction says to go through the whole tutorial so  linking to the middle of the tutorial is a bit confusing.

## I solemnly swear that:

- [x] I ran the hugo server and looked at my changed in the browser with my own eyes
- [ ] I ran the linter and there were no errors
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
