### PR TITLE
Guard against wildcard Imports

### DIFF
--- a/content/topics/clean-code/python/_index.md
+++ b/content/topics/clean-code/python/_index.md
@@ -125,34 +125,9 @@ and use `myclass.MyClass` and `foo.bar.yourclass.YourClass`.
 
 ### Wildcards
 
-Guard against wildcard imports. The primary reason is to ensure that imports are explicit is to prevent the cluttering of the namespace, else one of the following is likely to happen:
-- You have an outright naming conflict between your imports, for instance `maths.sqrt` and `statistics.sqrt`
-- Imports are sequential, thus the final wildcard's classes and functions will override whateter came before. Should this be the incorrect class or function, you will struggle to figure out why the code does not function as intended.
-- Ensures that the code is inkeeping with _Clean Code_ mantra as each import just _*"does one thing"*_, better still other users of the code can know at a glance which aspects of the import are meant to be used.
-- This also guards against changes to that get made to the imported module (such as an upgrade to Python or third party library), all of which could cause the above mentioned to occur down the line, long after the code has been merged.
-
-```
-# No:
-from math import *
-from statistics import *
-
-# Yes
-from math import cos, sin, tan
-from statistics import mean, median, mode
-```
-
-Should there still be a need to import multiple aspects of a module or a module in its entirety, attempt to import submodules, ensuring unique names and dot call whatever classes or functions you desire
-
-```
-import datetime as dt
-from datetime import datetime
-
-...
-
-if __name__ == "__main__":
-    print(dt.tzinfo())
-    print(datetime.tzinfo())
-```
+Guard against wildcard imports. For further details follow this links:
+- [Wildcard imports should not be used](https://rules.sonarsource.com/python/RSPEC-2208)
+- [Why You Should Avoid Wildcard Imports](https://www.youtube.com/shorts/A9AhKxSBZ0Q)
 
 In summary, wildcard imports should be avoided, as they make it unclear which names are present in the namespace, confusing both readers and many automated tools. There is one defensible use case for a wildcard import, which is to republish an internal interface as part of a public API (for example, overwriting a pure Python implementation of an interface with the definitions from an optional accelerator module and exactly which definitions will be overwritten isn't known in advance).
 

--- a/content/topics/clean-code/python/_index.md
+++ b/content/topics/clean-code/python/_index.md
@@ -125,7 +125,38 @@ and use `myclass.MyClass` and `foo.bar.yourclass.YourClass`.
 
 ### Wildcards
 
-Guard against wildcard imports. For further details follow this links:
+Guard against wildcard imports.
+
+```
+# No:
+from math import *
+from statistics import *
+
+# Yes
+from math import cos, sin, tan
+from statistics import mean, median, mode
+```
+
+The primary reason for ensuring that imports are explicit is to prevent the cluttering of the namespace, else one of the following is likely to happen:
+- You have an outright naming conflict between your imports, for instance `maths.sqrt` and `statistics.sqrt`
+- Imports are sequential, thus the final wildcard's classes and functions will override whateter came before. Should this be the incorrect class or function, you will struggle to figure out why the code does not function as intended.
+- Ensures that the code is inkeeping with the _Clean Code_ mantra as each import just _*"does one thing"*_, better still other users of the code can know at a glance which aspects of the import are meant to be used.
+- This also guards against changes that get made to the imported module (such as an upgrade to Python or third party library), all of which could cause the above mentioned to occur down the line, long after the code has been merged.
+
+Should there still be a need to import multiple aspects of a module or a module in its entirety, attempt to import submodules, ensuring unique names and dot call whatever classes or functions you desire
+
+```
+import datetime as dt
+from datetime import datetime
+
+...
+
+if __name__ == "__main__":
+    print(dt.tzinfo())
+    print(datetime.tzinfo())
+```
+
+For further details follow this links:
 - [Wildcard imports should not be used](https://rules.sonarsource.com/python/RSPEC-2208)
 - [Why You Should Avoid Wildcard Imports](https://www.youtube.com/shorts/A9AhKxSBZ0Q)
 

--- a/content/topics/clean-code/python/_index.md
+++ b/content/topics/clean-code/python/_index.md
@@ -75,6 +75,8 @@ Why? Because coders read code. If your comments just rewrite the code in English
 
 ## Imports
 
+### General Guideline
+
 Imports should usually be on separate lines:
 
 ```
@@ -92,15 +94,7 @@ It's okay to say this though:
 from subprocess import Popen, PIPE
 ```
 
-Guard against wildcard imports
-
-```
-# No:
-from math import *
-
-# Yes
-from math import cos, sin, tan
-```
+### Import Patterns
 
 Absolute imports are recommended, as they are usually more readable and tend to better behave (or at least give better error messages) if the import system is incorrectly configured (such as when a directory inside a package ends up on sys.path):
 
@@ -129,9 +123,38 @@ If this spelling causes local name clashes, then spell them explicitly:
 
 and use `myclass.MyClass` and `foo.bar.yourclass.YourClass`.
 
-- Wildcard imports (from <module> import \*) should be avoided, as they make it unclear which names are present in the namespace, confusing both readers and many automated tools. There is one defensible use case for a wildcard import, which is to republish an internal interface as part of a public API (for example, overwriting a pure Python implementation of an interface with the definitions from an optional accelerator module and exactly which definitions will be overwritten isn't known in advance).
+### Wildcards
 
-When republishing names this way, the guidelines below regarding public and internal interfaces still apply.
+Guard against wildcard imports. The primary reason is to ensure that imports are explicit is to prevent the cluttering of the namespace, else one of the following is likely to happen:
+- You have an outright naming conflict between your imports, for instance `maths.sqrt` and `statistics.sqrt`
+- Imports are sequential, thus the final wildcard's classes and functions will override whateter came before. Should this be the incorrect class or function, you will struggle to figure out why the code does not function as intended.
+- Ensures that the code is inkeeping with _Clean Code_ mantra as each import just _*"does one thing"*_, better still other users of the code can know at a glance which aspects of the import are meant to be used.
+- This also guards against changes to that get made to the imported module (such as an upgrade to Python or third party library), all of which could cause the above mentioned to occur down the line, long after the code has been merged.
+
+```
+# No:
+from math import *
+from statistics import *
+
+# Yes
+from math import cos, sin, tan
+from statistics import mean, median, mode
+```
+
+Should there still be a need to import multiple aspects of a module or a module in its entirety, attempt to import submodules, ensuring unique names and dot call whatever classes or functions you desire
+
+```
+import datetime as dt
+from datetime import datetime
+
+...
+
+if __name__ == "__main__":
+    print(dt.tzinfo())
+    print(datetime.tzinfo())
+```
+
+In summary, wildcard imports should be avoided, as they make it unclear which names are present in the namespace, confusing both readers and many automated tools. There is one defensible use case for a wildcard import, which is to republish an internal interface as part of a public API (for example, overwriting a pure Python implementation of an interface with the definitions from an optional accelerator module and exactly which definitions will be overwritten isn't known in advance).
 
 ## Strings
 

--- a/content/topics/clean-code/python/_index.md
+++ b/content/topics/clean-code/python/_index.md
@@ -75,8 +75,6 @@ Why? Because coders read code. If your comments just rewrite the code in English
 
 ## Imports
 
-### General Guideline
-
 Imports should usually be on separate lines:
 
 ```
@@ -94,8 +92,6 @@ It's okay to say this though:
 from subprocess import Popen, PIPE
 ```
 
-### Import Patterns
-
 Absolute imports are recommended, as they are usually more readable and tend to better behave (or at least give better error messages) if the import system is incorrectly configured (such as when a directory inside a package ends up on sys.path):
 
 ```
@@ -109,7 +105,7 @@ However, explicit relative imports are an acceptable alternative to absolute imp
       from . import sibling
       from .sibling import example
 
-  Standard library code should avoid complex package layouts and always use absolute imports. Implicit relative imports should never be used and have been removed in Python 3.
+Standard library code should avoid complex package layouts and always use absolute imports. Implicit relative imports should never be used and have been removed in Python 3.
 
 When importing a class from a class-containing module, it's usually okay to spell this:
 
@@ -123,9 +119,7 @@ If this spelling causes local name clashes, then spell them explicitly:
 
 and use `myclass.MyClass` and `foo.bar.yourclass.YourClass`.
 
-### Wildcards
-
-Guard against wildcard imports.
+When importing it's usually best to avoid using wildcards:
 
 ```
 # No:
@@ -137,30 +131,11 @@ from math import cos, sin, tan
 from statistics import mean, median, mode
 ```
 
-The primary reason for ensuring that imports are explicit is to prevent the cluttering of the namespace, else one of the following is likely to happen:
-- You have an outright naming conflict between your imports, for instance `maths.sqrt` and `statistics.sqrt`
-- Imports are sequential, thus the final wildcard's classes and functions will override whatever came before. Should this be the incorrect class or function, you will struggle to figure out why the code does not function as intended.
-- Ensures that the code is in keeping with the _Clean Code_ mantra as each import just _*"does one thing"*_, better still other users of the code can know at a glance which aspects of the import are meant to be used.
-- This also guards against changes that get made to the imported module (such as an upgrade to Python or a third-party library), all of which could cause the above-mentioned to occur down the line, long after the code has been merged.
-
-Should there still be a need to import multiple aspects of a module or a module in its entirety, attempt to import submodules, ensuring unique names and dot call whatever classes or functions you desire
-
-```
-import datetime as dt
-from datetime import datetime
-
-...
-
-if __name__ == "__main__":
-    print(dt.tzinfo())
-    print(datetime.tzinfo())
-```
+Wildcard imports (from import *) should be avoided, as they make it unclear which names are present in the namespace, confusing both readers and many automated tools. There is one defensible use case for a wildcard import, which is to republish an internal interface as part of a public API (for example, overwriting a pure Python implementation of an interface with the definitions from an optional accelerator module and exactly which definitions will be overwritten isn’t known in advance).
 
 For further details follow these links:
 - [Wildcard imports should not be used](https://rules.sonarsource.com/python/RSPEC-2208)
 - [Why You Should Avoid Wildcard Imports](https://www.youtube.com/shorts/A9AhKxSBZ0Q)
-
-In summary, wildcard imports should be avoided, as they make it unclear which names are present in the namespace, confusing both readers and many automated tools. There is one defensible use case for a wildcard import, which is to republish an internal interface as part of a public API (for example, overwriting a pure Python implementation of an interface with the definitions from an optional accelerator module and exactly which definitions will be overwritten isn't known in advance).
 
 ## Strings
 

--- a/content/topics/clean-code/python/_index.md
+++ b/content/topics/clean-code/python/_index.md
@@ -92,6 +92,16 @@ It's okay to say this though:
 from subprocess import Popen, PIPE
 ```
 
+Guard against wildcard imports
+
+```
+# No:
+from math import *
+
+# Yes
+from math import cos, sin, tan
+```
+
 Absolute imports are recommended, as they are usually more readable and tend to better behave (or at least give better error messages) if the import system is incorrectly configured (such as when a directory inside a package ends up on sys.path):
 
 ```

--- a/content/topics/clean-code/python/_index.md
+++ b/content/topics/clean-code/python/_index.md
@@ -139,9 +139,9 @@ from statistics import mean, median, mode
 
 The primary reason for ensuring that imports are explicit is to prevent the cluttering of the namespace, else one of the following is likely to happen:
 - You have an outright naming conflict between your imports, for instance `maths.sqrt` and `statistics.sqrt`
-- Imports are sequential, thus the final wildcard's classes and functions will override whateter came before. Should this be the incorrect class or function, you will struggle to figure out why the code does not function as intended.
-- Ensures that the code is inkeeping with the _Clean Code_ mantra as each import just _*"does one thing"*_, better still other users of the code can know at a glance which aspects of the import are meant to be used.
-- This also guards against changes that get made to the imported module (such as an upgrade to Python or third party library), all of which could cause the above mentioned to occur down the line, long after the code has been merged.
+- Imports are sequential, thus the final wildcard's classes and functions will override whatever came before. Should this be the incorrect class or function, you will struggle to figure out why the code does not function as intended.
+- Ensures that the code is in keeping with the _Clean Code_ mantra as each import just _*"does one thing"*_, better still other users of the code can know at a glance which aspects of the import are meant to be used.
+- This also guards against changes that get made to the imported module (such as an upgrade to Python or a third-party library), all of which could cause the above-mentioned to occur down the line, long after the code has been merged.
 
 Should there still be a need to import multiple aspects of a module or a module in its entirety, attempt to import submodules, ensuring unique names and dot call whatever classes or functions you desire
 
@@ -156,7 +156,7 @@ if __name__ == "__main__":
     print(datetime.tzinfo())
 ```
 
-For further details follow this links:
+For further details follow these links:
 - [Wildcard imports should not be used](https://rules.sonarsource.com/python/RSPEC-2208)
 - [Why You Should Avoid Wildcard Imports](https://www.youtube.com/shorts/A9AhKxSBZ0Q)
 


### PR DESCRIPTION
Advise against the use of wildcard imports by providing an example thereof

Related issues: clean code for Python

## Description:

We, recruits, consistently make wildcard imports when wishing to avoid having to specify exact imports. It may be wise to advise against such an act at a level higher than individual reviews.

## I solemnly swear that:

- [ ] I ran the hugo server and looked at my changed in the browser with my own eyes
- [ ] I ran the linter and there were no errors
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
