### PR TITLE
fixed link for recipe puppy

### DIFF
--- a/content/projects/recipe-search/part-1/_index.md
+++ b/content/projects/recipe-search/part-1/_index.md
@@ -2,23 +2,23 @@
 _db_id: 532
 content_type: project
 flavours:
-- javascript
-- typescript
+  - javascript
+  - typescript
 prerequisites:
   hard:
-  - projects/redux-intro/part-1
-  - projects/tilde-mockups
-  - topics/web-frontend/react/redux-architecture
+    - projects/redux-intro/part-1
+    - projects/tilde-mockups
+    - topics/web-frontend/react/redux-architecture
   soft: []
 ready: true
 submission_type: repo
 tags:
-- React
-- Redux
-title: 'React and Redux recipe search: Part 1. Presenting the form'
+  - React
+  - Redux
+title: "React and Redux recipe search: Part 1. Presenting the form"
 ---
 
-This is part 1 of a project where we will be using Redux in order to build a recipe search user interface based on the (RecipePuppy API)[content/projects/recipe-search/part-1].
+This is part 1 of a project where we will be using Redux in order to build a recipe search user interface based on the [RecipePuppy API](http://www.recipepuppy.com/about/api/).
 
 In this part of the excercise we wont be making any queries to the api, we'll just be using React and Redux to build a kick-ass search form.
 


### PR DESCRIPTION
Related issues: [please specify]

## Description:

I have realized that the link used in [part 1 ](http://syllabus.africacode.net/projects/recipe-search/part-1/)of recipe search is a link to part 1, instead of the recipepuppy link.
Before: 
![image](https://user-images.githubusercontent.com/52237474/182121545-302609e0-b465-4c1b-a438-9515fea66b6c.png)
After:
![image](https://user-images.githubusercontent.com/52237474/182121777-5baa1d91-c47b-4ebd-a0c2-ee7affe3bab8.png)


What are you up to? Fill us in :)

## I solemnly swear that:

- [x] I ran the hugo server and looked at my changed in the browser with my own eyes
- [ ] I ran the linter and there were no errors
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
