### PR TITLE
Update _index.md_Portfolio of work_Employability Sprint

### DIFF
--- a/content/employability-sprint/portfolio/_index.md
+++ b/content/employability-sprint/portfolio/_index.md
@@ -8,7 +8,7 @@ prerequisites:
 ready: true
 tags:
 - employability-sprint
-title: Portfolio of work
+title: Portfolio
 ---
 
 # GENERAL GUIDELINES

--- a/content/employability-sprint/portfolio/_index.md
+++ b/content/employability-sprint/portfolio/_index.md
@@ -8,5 +8,208 @@ prerequisites:
 ready: true
 tags:
 - employability-sprint
-title: Portfolio
+title: Portfolio of work
 ---
+
+# GENERAL GUIDELINES
+**Your portfolio** is the real substance and what employers really care about at the end of the day, as it answers the question: “What are you already able to do for us?”. When creating your portfolio, keep the following in mind:  
+
+- **You need both substance and polish.** You need to have solid projects, but you also need to package them well to concisely communicate what you can do. 
+- **Quality matters more than quantity.**  Two really powerful and relevant projects beat 10 generic projects. 
+- **Patience and perseverance.** [This article](https://towardsdatascience.com/how-to-build-a-data-science-portfolio-5f566517c79c) outlines a process for treating your portfolio as an iterative product for which you’re constantly seeking feedback, and to which you’re constantly making improvements. You can ask for feedback during interviews, or reach out to people in the field who might be willing to help. Constantly improving this “product” is a potential career game-changer! 
+
+There are at least two people at each hiring organisation who you’ll need to impress with your portfolio: 
+- **A recruiter** will be doing a quick scan of many, many CVs, digital profiles, and portfolios. Their task is to create a shortlist of candidates for the hiring manager. They’ll be looking for a set of projects that are **UNIQUE, well polished** (i.e. look great), and **display the relevant skills** for the job in question. 
+- **The hiring manager/team lead** will usually be more technically skilled and will be digging deeper into the projects of short-listed candidates. They’ll be more interested in things like code quality and how well you implemented best practices from the field, e.g. how good were your unit tests, or how well did you clean the real-world data you used? 
+
+If there’s one thing that’s repeated in all the advice we’ve read on portfolios, it’s that your projects need to stand out. They need a little personality. They should not be based on a walk-through tutorial – too many people use those. Ideally, they should deliver real-world value for someone – something which you should emphasise.
+
+For developers, you will be required to create the following accounts:
+- [Github](https://github.com/)
+
+For designers, you will also create the following accounts:
+- [Behance](https://www.behance.net/)
+- [Dribble](https://dribbble.com/)
+- Create your own website (useful sites: [Carbonmade](https://carbonmade.com/), [Wix](https://www.wix.com/), [WordPress](https://wordpress.com/), [Squarespace](https://www.squarespace.com/)) 
+
+There are many other industry-specific platforms and networks that you can also use. Here are some of the ones we recommend looking into:
+- [OfferZen](https://www.offerzen.com/)
+- [CoderBytes](https://coderbyte.com/) / [HackerRank](https://www.hackerrank.com/)
+
+### Additional resources
+Link to DPD UX/UI Design Portfolios
+# UX/UI DESIGN PORTFOLIOS
+Creating a portfolio of your work, no matter what field you are in, is often a useful way to communicate your practical skills and capabilities. This is the real substance and what employers really care about.
+
+It can exist as a stand-alone document like a PDF, a link to a personal website, or you can leverage an existing platform within your field, such as [Behance](https://www.behance.net/).
+ 
+We advise that your portfolio consists of a few practical projects that you’ve completed. You will use your portfolio to present these projects in a way that is clear. Try to structure the projects in a similar way to ensure consistency. 
+
+Each project has its own unique skill set or learning outcomes – keep that in mind and use that to your advantage. It is also helpful to show iterations of a solution (e.g. design or alternative technologies you tried) and how you refined your thinking.
+
+## Develop Your Design Portfolio
+
+### **Here are some tricks to help you develop your portfolio:** 
+- Keep the design simple so that it doesn't detract from your actual work
+- If you’re presenting a group brief, remember to identify the role you played and the work you did in the brief
+- Keep it succinct
+- Focus on your strengths
+- Include mockups of the final outcomes, reflecting the real-world context
+- Collaborate with others in your group (or others trying to break into the same industry) and exchange value – some of you design better than you write, and vice versa
+- A creative portfolio is meant to show how you solve problems, not perfect projects, and show the journey, the scamps, the pivots, the learnings, and the final product
+
+### **The following structure should help you lay out your portfolio:**
+
+**1. Cover page**
+
+**2. Contents page**
+
+**3. Introduction to you, your skills, and your strengths**
+
+*Project 1: Name*
+- Brief (explain the context and what was asked of you from the brief, as well as your role in the brief – this will help give your viewer more context)
+- Approach – the process you followed (briefly explain)
+- Research or Analysis (highlight the methods used, example requirements, elicitation interviews, desktop research, persona development, stakeholder interviews, market research, etc.)
+- Process Deliverables (e.g. BRD, stakeholder analysis, user flows, wireframes, project timeline, etc.)
+- Design Research or Feasibility Study (if applicable)
+- Solution or Process Results (e.g. define scope, budget and timelines , prototype, etc.)
+- Conclusion (learnings and impact to the project)
+
+*Project 2: Name*
+
+*Project 3: Name (if you have one)*
+
+*Project 4: Name (if you have one)*
+
+**4. Conclusion**
+
+**5. Thank yous + questions + contact details**
+
+
+## Presenting Your Design Portfolio
+When presenting your portfolio, you need to keep in mind that you would most likely have to present it in TWO forms. What do we mean by this? Firstly, you’d submit it remotely. And secondly, in person when you get the interview. Many establishments have now resorted to solely doing the interview process remotely, however, it’s important to be prepared for both.
+
+Your portfolio is what will get you the interview, so it’s very important to ensure the content you present is some of the best work you have done. A UX portfolio presentation is about showing your future employer and team that you can articulate your ideas, process, and concepts in a clear and concise style.
+
+Some of the important aspects that a future employer/recruiter may want to know more about are: 
+- **Role:** What were your responsibilities in the project?
+- **Team:** How did you work in the team and who did you work with? (stakeholders, developers, designers, product managers, etc.)
+- **Design insight:** What ideas helped develop your design?
+- **Design decisions:** How you translated business or user needs into your design?
+- **Rationale:** Explain why you chose to do things in that particular way during the project.
+
+## Prepare Your Presentation!
+
+### *Resources*
+[Case study template](https://www.figma.com/community/file/1009923427542573508)
+
+When designing your presentation, it’s important to consider the format (ask the manager if you are allowed to bring in your device to showcase your digital portfolio), to put together case studies for your projects, and to consider the following points: 
+- Which parts are necessary for comprehension?
+- Which part is the most powerful?
+- Which part can help you get the job at hand?
+
+You may not have much time to go into detail when preparing your work, so the points above will help to fine-tune the content for your presentation.
+
+Rehearsing your presentation is very important. Ensure you do not read from the slides and always come prepared with a bit of in-depth information for certain aspects of the design phase. 
+
+## Structure Your Presentation
+
+### *Resources*
+[UX portfolio example](http://blog.uxfol.io/ux-portfolio-examples/)
+
+Here are some tips on how to structure your presentation:
+1. Introduce yourself: Give them your name, your role, and what you specialise in
+2. Talk through a project you were passionate about or enjoyed working on (touch on the skills you used for this project, what went well, and how you overcame challenges.)
+3. Talk about the team setup, and your role and activity in a project
+4. Explain the challenges you faced
+5. Talk through your process (e.g. design thinking process)
+6. Mention UX methods and user insights (e.g. bucketing)
+7. Show the solution you developed 
+8. What was the major design decision you made? (This is moment you showcase the unexpected or impactful design decision that had an impact on the users)
+9. Showcase your results (prototype)
+10. Lastly, explain what you learnt from this project, show the findings of what you took away from this experience, and touch on how your thoughts may have evolved during the process 
+ 
+### *Some considerations for presenting*
+- Time (one of the most important aspects!) – manage your time well when presenting.
+- Easy-to-understand – not everyone will understand your professional lingo, so it’s important to speak in an understandable manner so everyone can follow along. 
+- Be excited about what you’re presenting – this is also very important. It allows the viewer to see your passion. 
+- Come prepared – DON’T READ FROM THE SLIDES! Always remember that the viewer is already reading the content on the screen and would lose interest if they are hearing it too. 
+- Lastly, be open to questions and ask for feedback. 
+
+## Online Presentation Prep
+
+When presenting your portfolio via Google meet or any other online platform, these are some of the things to keep in mind: 
+- Ensure your surroundings are neat and tidy. If your room is messy, they may think the same of you!
+- Close all tabs, bookmarks, and windows.
+- Double check your network connection and device settings.
+- Maintain camera contact, keep the engagement high. Do not be silent when asked a question or during a conversation. 
+
+## More Resources + Examples
+
+- [UX Designer's Portfolio template by The School of UX — Figma](https://www.figma.com/community/file/963394112012219151) 
+- [Folio 2020 • Product Design Portfolio Template — Figma](https://www.figma.com/community/file/897173001482039698) 
+- [UX Portfolio Structure & Template — Figma](https://www.figma.com/community/file/1101432807663232596) 
+- [Presentation Free Template — Figma](https://www.figma.com/community/file/999626768866067833) 
+- [Canva Templates](https://www.canva.com/templates/?query=CV)
+
+## THE END!
+
+Link to Tech portfolios 
+# TECH PORTFOLIOS
+## GitHub Profile Best Practices
+To assess the quality of your work, the hiring manager needs to access your raw code, which makes a solid GitHub profile essential. It needs to show the meaningful and impressive work you’ve done. The code should work reliably, and it needs to be clean and readable.
+
+This article covers some of the basic requirements for your GitHub profile, as well as some really great advice on keeping your profile active: [5 tips to power up your github profile](https://www.jobsity.com/blog/5-tips-to-power-up-your-github-profile)
+
+You don’t need to go overboard with the aesthetics, but a little can go a long way – particularly with the first-line recruiters who might be scouring through hundreds of profiles. This article covers some easy ways in which to add a little polish to your GitHub profile: [How to create a stunning Github profile](https://community.codenewbie.org/yuridevat/how-to-create-a-stunning-github-profile-1222) 
+
+[Here](https://github.com/abhisheknaiidu/awesome-github-profile-readme#a-little-bit-of-everything-) is a curated collection of great GitHub profiles. Some are better than others, so take the ideas you like and lose the ones you don’t. 
+
+It’s easy to get carried away with too much fancy “polishing” of your profile, so we highly recommend giving yourself a hard deadline on any beautification work. The most beautiful profile in the world won’t impress the hiring manager if the projects in the portfolio aren’t great. 
+
+## Web Dev Portfolios
+[This article](https://www.freecodecamp.org/news/level-up-developer-portfolio/) from the awesome team at freeCodeCamp outlines some of the minimum requirements for a Web Developer portfolio site. It then provides five great tips for powering up your profile beyond just the basics.  
+
+You can find some other great ideas and additional inspiration over here: 
+[21 Best Developer Portfolio Examples](https://hackernoon.com/21-best-developer-portfolio-examples-p61j31wi)
+
+## Data Science Portfolios
+It is worth emphasising again: **Your projects need to help you stand out!** 
+
+Early-career data scientists are particularly prone to listing generic projects in their portfolios. Everyone has done the Titanic survival predictions or hand-writing recognition on the MNIST data set. These generic projects are great for your learning, given the huge community that’s built supporting resources around them, but they really shouldn’t be a core part of your portfolio. Nor should any other projects that come with a walk-through tutorial on YouTube. 
+
+Again, we suggest an iterative approach based on real-world problems. Find a topic that interests you and ask a question about it. Next, find data to answer your question. You can then publicly post your results and ask for some feedback. Rinse and repeat. 
+
+Even better – see if you can find a real client! Even if they don’t pay you just yet, it’ll be super useful to build something that adds tangible value in the real world and has meaningful deadlines attached to it.  
+
+Sometimes it’s better to learn in a team. Engage with some competition communities and see if you can find a team who’s willing to take you on. Ideally, you’ll want a team with at least a little competition experience. 
+
+[Kaggle](https://www.kaggle.com/) and [Zindi](https://zindi.africa/) are great places to start. 
+
+[This article](https://medium.com/@jasonkgoodman/advice-on-building-data-portfolio-projects-c5f96d8a0627) has some wonderful advice for data portfolio projects: 
+- Use real data/scrape your own data/use publicly accessible APIs
+- Pick something you’re curious about, not something you hope will be impressive
+- Pick an analysis that is interesting, regardless of what you find
+- Perfect the visuals/keep the text short/make your data interactive
+- Productionise your analysis if possible/put the code on GitHub
+- **Seek feedback** (Remember the [iterative approach to portfolio building](https://towardsdatascience.com/how-to-build-a-data-science-portfolio-5f566517c79c): “Don’t be afraid to keep adding on to or editing your projects after they’re published!”)
+
+This great [article from dataquest.io](https://www.dataquest.io/blog/build-a-data-science-portfolio/) provides a very useful overview of what employers are actually looking for in your portfolio. It also covers the basic types of projects you should include in your portfolio. (We’re not huge fans of the Explanatory Post – but otherwise, their advice is solid!) 
+
+Finally, for a bit of polish, we really like [datascienceportfol.io](http://datascienceportfol.io) as a quick and easy way to show off your projects in a concise, elegant, and visually appealing way. 
+You might find some inspiration in the portfolios below: 
+- [FisherKK](https://github.com/FisherKK/F1sherKK-MyRoadToAI) (GitHub) – a nice way to group similar projects, and to highlight coursework you’ve done. 
+- [https://otoro.net/ml/](https://otoro.net/ml/) – beautiful visuals! Plus a very clean and tidy structure, with wonderfully concise yet descriptive project overviews. 
+
+## THE END!
+
+
+
+### *Highlighting Work You Did With An Employer*
+Unfortunately, there’s bound to be some work that you do with employers/clients that you can’t show in full on your portfolio. For example, most employers won’t want you sharing their entire code base with the outside world. 
+
+That said, there’s little preventing you from sharing a high-level summary of a project you worked on. The summary could outline the problems you solved and how you did so. As long as it’s not giving away any “secret sauce” that the company wouldn’t want to share publicly, you can always package it as a “case study” or even as a bullet point explanation on your CV. 
+
+If you’re unsure about it, it’s best to check with your client/employer first, as there can be legal implications to sharing stuff they’d prefer to keep private. Depending on the type of organisation, they might be very comfortable letting you share some of the snippets of code you wrote or screenshots of dashboards you built, etc.  
+
+## THE END!

--- a/content/employability-sprint/portfolio/_index.md
+++ b/content/employability-sprint/portfolio/_index.md
@@ -45,7 +45,7 @@ There are many other industry-specific platforms and networks that you can also 
 
  - {{% contentlink path="employability-sprint/portfolio/tech_specific" %}}
 
-### *Highlighting Work You Did With An Employer*
+### Highlighting Work You Did With An Employer
 Unfortunately, there’s bound to be some work that you do with employers/clients that you can’t show in full on your portfolio. For example, most employers won’t want you sharing their entire code base with the outside world. 
 
 That said, there’s little preventing you from sharing a high-level summary of a project you worked on. The summary could outline the problems you solved and how you did so. As long as it’s not giving away any “secret sauce” that the company wouldn’t want to share publicly, you can always package it as a “case study” or even as a bullet point explanation on your CV. 

--- a/content/employability-sprint/portfolio/_index.md
+++ b/content/employability-sprint/portfolio/_index.md
@@ -25,185 +25,25 @@ There are at least two people at each hiring organisation who you’ll need to i
 If there’s one thing that’s repeated in all the advice we’ve read on portfolios, it’s that your projects need to stand out. They need a little personality. They should not be based on a walk-through tutorial – too many people use those. Ideally, they should deliver real-world value for someone – something which you should emphasise.
 
 For developers, you will be required to create the following accounts:
+
 - [Github](https://github.com/)
 
 For designers, you will also create the following accounts:
+
 - [Behance](https://www.behance.net/)
 - [Dribble](https://dribbble.com/)
 - Create your own website (useful sites: [Carbonmade](https://carbonmade.com/), [Wix](https://www.wix.com/), [WordPress](https://wordpress.com/), [Squarespace](https://www.squarespace.com/)) 
 
 There are many other industry-specific platforms and networks that you can also use. Here are some of the ones we recommend looking into:
+
 - [OfferZen](https://www.offerzen.com/)
 - [CoderBytes](https://coderbyte.com/) / [HackerRank](https://www.hackerrank.com/)
 
 ### Additional resources
-Link to DPD UX/UI Design Portfolios
-# UX/UI DESIGN PORTFOLIOS
-Creating a portfolio of your work, no matter what field you are in, is often a useful way to communicate your practical skills and capabilities. This is the real substance and what employers really care about.
 
-It can exist as a stand-alone document like a PDF, a link to a personal website, or you can leverage an existing platform within your field, such as [Behance](https://www.behance.net/).
- 
-We advise that your portfolio consists of a few practical projects that you’ve completed. You will use your portfolio to present these projects in a way that is clear. Try to structure the projects in a similar way to ensure consistency. 
+ - {{% contentlink path="employability-sprint/portfolio/dpd_specific" %}}
 
-Each project has its own unique skill set or learning outcomes – keep that in mind and use that to your advantage. It is also helpful to show iterations of a solution (e.g. design or alternative technologies you tried) and how you refined your thinking.
-
-## Develop Your Design Portfolio
-
-### **Here are some tricks to help you develop your portfolio:** 
-- Keep the design simple so that it doesn't detract from your actual work
-- If you’re presenting a group brief, remember to identify the role you played and the work you did in the brief
-- Keep it succinct
-- Focus on your strengths
-- Include mockups of the final outcomes, reflecting the real-world context
-- Collaborate with others in your group (or others trying to break into the same industry) and exchange value – some of you design better than you write, and vice versa
-- A creative portfolio is meant to show how you solve problems, not perfect projects, and show the journey, the scamps, the pivots, the learnings, and the final product
-
-### **The following structure should help you lay out your portfolio:**
-
-**1. Cover page**
-
-**2. Contents page**
-
-**3. Introduction to you, your skills, and your strengths**
-
-*Project 1: Name*
-- Brief (explain the context and what was asked of you from the brief, as well as your role in the brief – this will help give your viewer more context)
-- Approach – the process you followed (briefly explain)
-- Research or Analysis (highlight the methods used, example requirements, elicitation interviews, desktop research, persona development, stakeholder interviews, market research, etc.)
-- Process Deliverables (e.g. BRD, stakeholder analysis, user flows, wireframes, project timeline, etc.)
-- Design Research or Feasibility Study (if applicable)
-- Solution or Process Results (e.g. define scope, budget and timelines , prototype, etc.)
-- Conclusion (learnings and impact to the project)
-
-*Project 2: Name*
-
-*Project 3: Name (if you have one)*
-
-*Project 4: Name (if you have one)*
-
-**4. Conclusion**
-
-**5. Thank yous + questions + contact details**
-
-
-## Presenting Your Design Portfolio
-When presenting your portfolio, you need to keep in mind that you would most likely have to present it in TWO forms. What do we mean by this? Firstly, you’d submit it remotely. And secondly, in person when you get the interview. Many establishments have now resorted to solely doing the interview process remotely, however, it’s important to be prepared for both.
-
-Your portfolio is what will get you the interview, so it’s very important to ensure the content you present is some of the best work you have done. A UX portfolio presentation is about showing your future employer and team that you can articulate your ideas, process, and concepts in a clear and concise style.
-
-Some of the important aspects that a future employer/recruiter may want to know more about are: 
-- **Role:** What were your responsibilities in the project?
-- **Team:** How did you work in the team and who did you work with? (stakeholders, developers, designers, product managers, etc.)
-- **Design insight:** What ideas helped develop your design?
-- **Design decisions:** How you translated business or user needs into your design?
-- **Rationale:** Explain why you chose to do things in that particular way during the project.
-
-## Prepare Your Presentation!
-
-### *Resources*
-[Case study template](https://www.figma.com/community/file/1009923427542573508)
-
-When designing your presentation, it’s important to consider the format (ask the manager if you are allowed to bring in your device to showcase your digital portfolio), to put together case studies for your projects, and to consider the following points: 
-- Which parts are necessary for comprehension?
-- Which part is the most powerful?
-- Which part can help you get the job at hand?
-
-You may not have much time to go into detail when preparing your work, so the points above will help to fine-tune the content for your presentation.
-
-Rehearsing your presentation is very important. Ensure you do not read from the slides and always come prepared with a bit of in-depth information for certain aspects of the design phase. 
-
-## Structure Your Presentation
-
-### *Resources*
-[UX portfolio example](http://blog.uxfol.io/ux-portfolio-examples/)
-
-Here are some tips on how to structure your presentation:
-1. Introduce yourself: Give them your name, your role, and what you specialise in
-2. Talk through a project you were passionate about or enjoyed working on (touch on the skills you used for this project, what went well, and how you overcame challenges.)
-3. Talk about the team setup, and your role and activity in a project
-4. Explain the challenges you faced
-5. Talk through your process (e.g. design thinking process)
-6. Mention UX methods and user insights (e.g. bucketing)
-7. Show the solution you developed 
-8. What was the major design decision you made? (This is moment you showcase the unexpected or impactful design decision that had an impact on the users)
-9. Showcase your results (prototype)
-10. Lastly, explain what you learnt from this project, show the findings of what you took away from this experience, and touch on how your thoughts may have evolved during the process 
- 
-### *Some considerations for presenting*
-- Time (one of the most important aspects!) – manage your time well when presenting.
-- Easy-to-understand – not everyone will understand your professional lingo, so it’s important to speak in an understandable manner so everyone can follow along. 
-- Be excited about what you’re presenting – this is also very important. It allows the viewer to see your passion. 
-- Come prepared – DON’T READ FROM THE SLIDES! Always remember that the viewer is already reading the content on the screen and would lose interest if they are hearing it too. 
-- Lastly, be open to questions and ask for feedback. 
-
-## Online Presentation Prep
-
-When presenting your portfolio via Google meet or any other online platform, these are some of the things to keep in mind: 
-- Ensure your surroundings are neat and tidy. If your room is messy, they may think the same of you!
-- Close all tabs, bookmarks, and windows.
-- Double check your network connection and device settings.
-- Maintain camera contact, keep the engagement high. Do not be silent when asked a question or during a conversation. 
-
-## More Resources + Examples
-
-- [UX Designer's Portfolio template by The School of UX — Figma](https://www.figma.com/community/file/963394112012219151) 
-- [Folio 2020 • Product Design Portfolio Template — Figma](https://www.figma.com/community/file/897173001482039698) 
-- [UX Portfolio Structure & Template — Figma](https://www.figma.com/community/file/1101432807663232596) 
-- [Presentation Free Template — Figma](https://www.figma.com/community/file/999626768866067833) 
-- [Canva Templates](https://www.canva.com/templates/?query=CV)
-
-## THE END!
-
-Link to Tech portfolios 
-# TECH PORTFOLIOS
-## GitHub Profile Best Practices
-To assess the quality of your work, the hiring manager needs to access your raw code, which makes a solid GitHub profile essential. It needs to show the meaningful and impressive work you’ve done. The code should work reliably, and it needs to be clean and readable.
-
-This article covers some of the basic requirements for your GitHub profile, as well as some really great advice on keeping your profile active: [5 tips to power up your github profile](https://www.jobsity.com/blog/5-tips-to-power-up-your-github-profile)
-
-You don’t need to go overboard with the aesthetics, but a little can go a long way – particularly with the first-line recruiters who might be scouring through hundreds of profiles. This article covers some easy ways in which to add a little polish to your GitHub profile: [How to create a stunning Github profile](https://community.codenewbie.org/yuridevat/how-to-create-a-stunning-github-profile-1222) 
-
-[Here](https://github.com/abhisheknaiidu/awesome-github-profile-readme#a-little-bit-of-everything-) is a curated collection of great GitHub profiles. Some are better than others, so take the ideas you like and lose the ones you don’t. 
-
-It’s easy to get carried away with too much fancy “polishing” of your profile, so we highly recommend giving yourself a hard deadline on any beautification work. The most beautiful profile in the world won’t impress the hiring manager if the projects in the portfolio aren’t great. 
-
-## Web Dev Portfolios
-[This article](https://www.freecodecamp.org/news/level-up-developer-portfolio/) from the awesome team at freeCodeCamp outlines some of the minimum requirements for a Web Developer portfolio site. It then provides five great tips for powering up your profile beyond just the basics.  
-
-You can find some other great ideas and additional inspiration over here: 
-[21 Best Developer Portfolio Examples](https://hackernoon.com/21-best-developer-portfolio-examples-p61j31wi)
-
-## Data Science Portfolios
-It is worth emphasising again: **Your projects need to help you stand out!** 
-
-Early-career data scientists are particularly prone to listing generic projects in their portfolios. Everyone has done the Titanic survival predictions or hand-writing recognition on the MNIST data set. These generic projects are great for your learning, given the huge community that’s built supporting resources around them, but they really shouldn’t be a core part of your portfolio. Nor should any other projects that come with a walk-through tutorial on YouTube. 
-
-Again, we suggest an iterative approach based on real-world problems. Find a topic that interests you and ask a question about it. Next, find data to answer your question. You can then publicly post your results and ask for some feedback. Rinse and repeat. 
-
-Even better – see if you can find a real client! Even if they don’t pay you just yet, it’ll be super useful to build something that adds tangible value in the real world and has meaningful deadlines attached to it.  
-
-Sometimes it’s better to learn in a team. Engage with some competition communities and see if you can find a team who’s willing to take you on. Ideally, you’ll want a team with at least a little competition experience. 
-
-[Kaggle](https://www.kaggle.com/) and [Zindi](https://zindi.africa/) are great places to start. 
-
-[This article](https://medium.com/@jasonkgoodman/advice-on-building-data-portfolio-projects-c5f96d8a0627) has some wonderful advice for data portfolio projects: 
-- Use real data/scrape your own data/use publicly accessible APIs
-- Pick something you’re curious about, not something you hope will be impressive
-- Pick an analysis that is interesting, regardless of what you find
-- Perfect the visuals/keep the text short/make your data interactive
-- Productionise your analysis if possible/put the code on GitHub
-- **Seek feedback** (Remember the [iterative approach to portfolio building](https://towardsdatascience.com/how-to-build-a-data-science-portfolio-5f566517c79c): “Don’t be afraid to keep adding on to or editing your projects after they’re published!”)
-
-This great [article from dataquest.io](https://www.dataquest.io/blog/build-a-data-science-portfolio/) provides a very useful overview of what employers are actually looking for in your portfolio. It also covers the basic types of projects you should include in your portfolio. (We’re not huge fans of the Explanatory Post – but otherwise, their advice is solid!) 
-
-Finally, for a bit of polish, we really like [datascienceportfol.io](http://datascienceportfol.io) as a quick and easy way to show off your projects in a concise, elegant, and visually appealing way. 
-You might find some inspiration in the portfolios below: 
-- [FisherKK](https://github.com/FisherKK/F1sherKK-MyRoadToAI) (GitHub) – a nice way to group similar projects, and to highlight coursework you’ve done. 
-- [https://otoro.net/ml/](https://otoro.net/ml/) – beautiful visuals! Plus a very clean and tidy structure, with wonderfully concise yet descriptive project overviews. 
-
-## THE END!
-
-
+ - {{% contentlink path="employability-sprint/portfolio/tech_specific" %}}
 
 ### *Highlighting Work You Did With An Employer*
 Unfortunately, there’s bound to be some work that you do with employers/clients that you can’t show in full on your portfolio. For example, most employers won’t want you sharing their entire code base with the outside world. 
@@ -211,5 +51,3 @@ Unfortunately, there’s bound to be some work that you do with employers/client
 That said, there’s little preventing you from sharing a high-level summary of a project you worked on. The summary could outline the problems you solved and how you did so. As long as it’s not giving away any “secret sauce” that the company wouldn’t want to share publicly, you can always package it as a “case study” or even as a bullet point explanation on your CV. 
 
 If you’re unsure about it, it’s best to check with your client/employer first, as there can be legal implications to sharing stuff they’d prefer to keep private. Depending on the type of organisation, they might be very comfortable letting you share some of the snippets of code you wrote or screenshots of dashboards you built, etc.  
-
-## THE END!

--- a/content/employability-sprint/portfolio/dpd_specific/_index.md
+++ b/content/employability-sprint/portfolio/dpd_specific/_index.md
@@ -1,0 +1,125 @@
+---
+content_type: topic
+learning_outcomes: null
+prerequisites:
+  hard: null
+  soft: []
+ready: true
+tags:
+- employability-sprint
+title: Portfolio of work - digital product design guidelines
+---
+
+# UX/UI DESIGN PORTFOLIOS
+Creating a portfolio of your work, no matter what field you are in, is often a useful way to communicate your practical skills and capabilities. This is the real substance and what employers really care about.
+
+It can exist as a stand-alone document like a PDF, a link to a personal website, or you can leverage an existing platform within your field, such as [Behance](https://www.behance.net/).
+ 
+We advise that your portfolio consists of a few practical projects that you’ve completed. You will use your portfolio to present these projects in a way that is clear. Try to structure the projects in a similar way to ensure consistency. 
+
+Each project has its own unique skill set or learning outcomes – keep that in mind and use that to your advantage. It is also helpful to show iterations of a solution (e.g. design or alternative technologies you tried) and how you refined your thinking.
+
+## Develop Your Design Portfolio
+
+### **Here are some tricks to help you develop your portfolio:** 
+- Keep the design simple so that it doesn't detract from your actual work
+- If you’re presenting a group brief, remember to identify the role you played and the work you did in the brief
+- Keep it succinct
+- Focus on your strengths
+- Include mockups of the final outcomes, reflecting the real-world context
+- Collaborate with others in your group (or others trying to break into the same industry) and exchange value – some of you design better than you write, and vice versa
+- A creative portfolio is meant to show how you solve problems, not perfect projects, and show the journey, the scamps, the pivots, the learnings, and the final product
+
+### **The following structure should help you lay out your portfolio:**
+
+**1. Cover page**
+
+**2. Contents page**
+
+**3. Introduction to you, your skills, and your strengths**
+
+*Project 1: Name*
+- Brief (explain the context and what was asked of you from the brief, as well as your role in the brief – this will help give your viewer more context)
+- Approach – the process you followed (briefly explain)
+- Research or Analysis (highlight the methods used, example requirements, elicitation interviews, desktop research, persona development, stakeholder interviews, market research, etc.)
+- Process Deliverables (e.g. BRD, stakeholder analysis, user flows, wireframes, project timeline, etc.)
+- Design Research or Feasibility Study (if applicable)
+- Solution or Process Results (e.g. define scope, budget and timelines , prototype, etc.)
+- Conclusion (learnings and impact to the project)
+
+*Project 2: Name*
+
+*Project 3: Name (if you have one)*
+
+*Project 4: Name (if you have one)*
+
+**4. Conclusion**
+
+**5. Thank yous + questions + contact details**
+
+
+## Presenting Your Design Portfolio
+When presenting your portfolio, you need to keep in mind that you would most likely have to present it in TWO forms. What do we mean by this? Firstly, you’d submit it remotely. And secondly, in person when you get the interview. Many establishments have now resorted to solely doing the interview process remotely, however, it’s important to be prepared for both.
+
+Your portfolio is what will get you the interview, so it’s very important to ensure the content you present is some of the best work you have done. A UX portfolio presentation is about showing your future employer and team that you can articulate your ideas, process, and concepts in a clear and concise style.
+
+Some of the important aspects that a future employer/recruiter may want to know more about are: 
+- **Role:** What were your responsibilities in the project?
+- **Team:** How did you work in the team and who did you work with? (stakeholders, developers, designers, product managers, etc.)
+- **Design insight:** What ideas helped develop your design?
+- **Design decisions:** How you translated business or user needs into your design?
+- **Rationale:** Explain why you chose to do things in that particular way during the project.
+
+## Prepare Your Presentation!
+
+### Resources
+[Case study template](https://www.figma.com/community/file/1009923427542573508)
+
+When designing your presentation, it’s important to consider the format (ask the manager if you are allowed to bring in your device to showcase your digital portfolio), to put together case studies for your projects, and to consider the following points: 
+- Which parts are necessary for comprehension?
+- Which part is the most powerful?
+- Which part can help you get the job at hand?
+
+You may not have much time to go into detail when preparing your work, so the points above will help to fine-tune the content for your presentation.
+
+Rehearsing your presentation is very important. Ensure you do not read from the slides and always come prepared with a bit of in-depth information for certain aspects of the design phase. 
+
+## Structure Your Presentation
+
+### Resources
+[UX portfolio example](http://blog.uxfol.io/ux-portfolio-examples/)
+
+Here are some tips on how to structure your presentation:
+1. Introduce yourself: Give them your name, your role, and what you specialise in
+2. Talk through a project you were passionate about or enjoyed working on (touch on the skills you used for this project, what went well, and how you overcame challenges.)
+3. Talk about the team setup, and your role and activity in a project
+4. Explain the challenges you faced
+5. Talk through your process (e.g. design thinking process)
+6. Mention UX methods and user insights (e.g. bucketing)
+7. Show the solution you developed 
+8. What was the major design decision you made? (This is moment you showcase the unexpected or impactful design decision that had an impact on the users)
+9. Showcase your results (prototype)
+10. Lastly, explain what you learnt from this project, show the findings of what you took away from this experience, and touch on how your thoughts may have evolved during the process 
+ 
+### Some considerations for presenting
+- Time (one of the most important aspects!) – manage your time well when presenting.
+- Easy-to-understand – not everyone will understand your professional lingo, so it’s important to speak in an understandable manner so everyone can follow along. 
+- Be excited about what you’re presenting – this is also very important. It allows the viewer to see your passion. 
+- Come prepared – DON’T READ FROM THE SLIDES! Always remember that the viewer is already reading the content on the screen and would lose interest if they are hearing it too. 
+- Lastly, be open to questions and ask for feedback. 
+
+## Online Presentation Prep
+
+When presenting your portfolio via Google meet or any other online platform, these are some of the things to keep in mind: 
+- Ensure your surroundings are neat and tidy. If your room is messy, they may think the same of you!
+- Close all tabs, bookmarks, and windows.
+- Double check your network connection and device settings.
+- Maintain camera contact, keep the engagement high. Do not be silent when asked a question or during a conversation. 
+
+## More Resources + Examples
+
+- [UX Designer's Portfolio template by The School of UX — Figma](https://www.figma.com/community/file/963394112012219151) 
+- [Folio 2020 • Product Design Portfolio Template — Figma](https://www.figma.com/community/file/897173001482039698) 
+- [UX Portfolio Structure & Template — Figma](https://www.figma.com/community/file/1101432807663232596) 
+- [Presentation Free Template — Figma](https://www.figma.com/community/file/999626768866067833) 
+- [Canva Templates](https://www.canva.com/templates/?query=CV)

--- a/content/employability-sprint/portfolio/tech_specific/_index.md
+++ b/content/employability-sprint/portfolio/tech_specific/_index.md
@@ -1,5 +1,4 @@
 ---
-_db_id: 819
 content_type: topic
 learning_outcomes: null
 prerequisites:

--- a/content/employability-sprint/portfolio/tech_specific/_index.md
+++ b/content/employability-sprint/portfolio/tech_specific/_index.md
@@ -1,0 +1,59 @@
+---
+_db_id: 819
+content_type: topic
+learning_outcomes: null
+prerequisites:
+  hard: null
+  soft: []
+ready: true
+tags:
+- employability-sprint
+title: Portfolio of work - tech guidelines
+---
+
+# TECH PORTFOLIOS
+## GitHub Profile Best Practices
+To assess the quality of your work, the hiring manager needs to access your raw code, which makes a solid GitHub profile essential. It needs to show the meaningful and impressive work you’ve done. The code should work reliably, and it needs to be clean and readable.
+
+This article covers some of the basic requirements for your GitHub profile, as well as some really great advice on keeping your profile active: [5 tips to power up your github profile](https://www.jobsity.com/blog/5-tips-to-power-up-your-github-profile)
+
+You don’t need to go overboard with the aesthetics, but a little can go a long way – particularly with the first-line recruiters who might be scouring through hundreds of profiles. This article covers some easy ways in which to add a little polish to your GitHub profile: [How to create a stunning Github profile](https://community.codenewbie.org/yuridevat/how-to-create-a-stunning-github-profile-1222) 
+
+[Here](https://github.com/abhisheknaiidu/awesome-github-profile-readme#a-little-bit-of-everything-) is a curated collection of great GitHub profiles. Some are better than others, so take the ideas you like and lose the ones you don’t. 
+
+It’s easy to get carried away with too much fancy “polishing” of your profile, so we highly recommend giving yourself a hard deadline on any beautification work. The most beautiful profile in the world won’t impress the hiring manager if the projects in the portfolio aren’t great. 
+
+## Web Dev Portfolios
+[This article](https://www.freecodecamp.org/news/level-up-developer-portfolio/) from the awesome team at freeCodeCamp outlines some of the minimum requirements for a Web Developer portfolio site. It then provides five great tips for powering up your profile beyond just the basics.  
+
+You can find some other great ideas and additional inspiration over here: 
+[21 Best Developer Portfolio Examples](https://hackernoon.com/21-best-developer-portfolio-examples-p61j31wi)
+
+## Data Science Portfolios
+It is worth emphasising again: **Your projects need to help you stand out!** 
+
+Early-career data scientists are particularly prone to listing generic projects in their portfolios. Everyone has done the Titanic survival predictions or hand-writing recognition on the MNIST data set. These generic projects are great for your learning, given the huge community that’s built supporting resources around them, but they really shouldn’t be a core part of your portfolio. Nor should any other projects that come with a walk-through tutorial on YouTube. 
+
+Again, we suggest an iterative approach based on real-world problems. Find a topic that interests you and ask a question about it. Next, find data to answer your question. You can then publicly post your results and ask for some feedback. Rinse and repeat. 
+
+Even better – see if you can find a real client! Even if they don’t pay you just yet, it’ll be super useful to build something that adds tangible value in the real world and has meaningful deadlines attached to it.  
+
+Sometimes it’s better to learn in a team. Engage with some competition communities and see if you can find a team who’s willing to take you on. Ideally, you’ll want a team with at least a little competition experience. 
+
+[Kaggle](https://www.kaggle.com/) and [Zindi](https://zindi.africa/) are great places to start. 
+
+[This article](https://medium.com/@jasonkgoodman/advice-on-building-data-portfolio-projects-c5f96d8a0627) has some wonderful advice for data portfolio projects: 
+- Use real data/scrape your own data/use publicly accessible APIs
+- Pick something you’re curious about, not something you hope will be impressive
+- Pick an analysis that is interesting, regardless of what you find
+- Perfect the visuals/keep the text short/make your data interactive
+- Productionise your analysis if possible/put the code on GitHub
+- **Seek feedback** (Remember the [iterative approach to portfolio building](https://towardsdatascience.com/how-to-build-a-data-science-portfolio-5f566517c79c): “Don’t be afraid to keep adding on to or editing your projects after they’re published!”)
+
+This great [article from dataquest.io](https://www.dataquest.io/blog/build-a-data-science-portfolio/) provides a very useful overview of what employers are actually looking for in your portfolio. It also covers the basic types of projects you should include in your portfolio. (We’re not huge fans of the Explanatory Post – but otherwise, their advice is solid!) 
+
+Finally, for a bit of polish, we really like [datascienceportfol.io](http://datascienceportfol.io) as a quick and easy way to show off your projects in a concise, elegant, and visually appealing way. 
+You might find some inspiration in the portfolios below: 
+- [FisherKK](https://github.com/FisherKK/F1sherKK-MyRoadToAI) (GitHub) – a nice way to group similar projects, and to highlight coursework you’ve done. 
+- [https://otoro.net/ml/](https://otoro.net/ml/) – beautiful visuals! Plus a very clean and tidy structure, with wonderfully concise yet descriptive project overviews. 
+

--- a/content/employability-sprint/portfolio/tech_specific/_index.md
+++ b/content/employability-sprint/portfolio/tech_specific/_index.md
@@ -42,6 +42,7 @@ Sometimes it’s better to learn in a team. Engage with some competition communi
 [Kaggle](https://www.kaggle.com/) and [Zindi](https://zindi.africa/) are great places to start. 
 
 [This article](https://medium.com/@jasonkgoodman/advice-on-building-data-portfolio-projects-c5f96d8a0627) has some wonderful advice for data portfolio projects: 
+
 - Use real data/scrape your own data/use publicly accessible APIs
 - Pick something you’re curious about, not something you hope will be impressive
 - Pick an analysis that is interesting, regardless of what you find
@@ -53,6 +54,7 @@ This great [article from dataquest.io](https://www.dataquest.io/blog/build-a-dat
 
 Finally, for a bit of polish, we really like [datascienceportfol.io](http://datascienceportfol.io) as a quick and easy way to show off your projects in a concise, elegant, and visually appealing way. 
 You might find some inspiration in the portfolios below: 
+
 - [FisherKK](https://github.com/FisherKK/F1sherKK-MyRoadToAI) (GitHub) – a nice way to group similar projects, and to highlight coursework you’ve done. 
 - [https://otoro.net/ml/](https://otoro.net/ml/) – beautiful visuals! Plus a very clean and tidy structure, with wonderfully concise yet descriptive project overviews. 
 


### PR DESCRIPTION
1. First linked article after 'Patience and perseverance' is Data Science and not general. Should we change this?
2. Should we move additional resources with links to DPD and Tech to end of the document?

3. Split off Link to DPD UX/UI Design Portfolios
4. Split off Link to Tech portfolios

Related issues: [please specify]

## Description:

What are you up to? Fill us in :)

## I solemnly swear that:

- [x] I ran the hugo server and looked at my changed in the browser with my own eyes
- [x] I ran the linter and there were no errors
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
