### PR TITLE
NLP Library: Consistency between the topic and the project

### DIFF
--- a/content/projects/data-science-specific/natural-language-processing/_index.md
+++ b/content/projects/data-science-specific/natural-language-processing/_index.md
@@ -31,7 +31,7 @@ The contents of the State of the Nation Address (SONA) for every year dating bac
 
 1. Create a corpus from the English-language text for the SONAs dating back to 2000. Save them with the speaker information and date for later analysis. Where there is more than one SONA per year, get both.
 
-2. Use `NLTK` to create a document-term matrix from the text. To do this, the text should be:  
+2. Use `spaCy` to create a document-term matrix from the text. To do this, the text should be:  
 
   * in lowercase with punctuation and numbers removed (tip: use regular expressions)
   * tokenized and lemmatized
@@ -44,6 +44,6 @@ The contents of the State of the Nation Address (SONA) for every year dating bac
 
 5. Create word clouds to visualise the speeches for each president. What are the main issues that they talked about during their presidency?
 
-6. Use TextBlob to do sentiment analysis of the SONAs. Get the polarity and subjectivity for each SONA and visualise the changes in polarity and subjectivity over time. Also create a graph of the average polarity and subjectivity by president. Do you notice any patterns?
+6. Use [spaCy-TextBlob](https://spacy.io/universe/project/spacy-textblob) to do sentiment analysis of the SONAs. Get the polarity and subjectivity for each SONA and visualise the changes in polarity and subjectivity over time. Also create a graph of the average polarity and subjectivity by president. Do you notice any patterns?
 
 7. How have focus areas and sentiment in the SONAs changed over the last twenty years in South Africa? Are there clear changes in focus areas between different presidents?


### PR DESCRIPTION
- [Topic](https://github.com/Umuzi-org/ACN-syllabus/blob/develop/content/topics/data-science-specific/natural-language-processing/_index.md): Herein we are told that we will use `spaCy` as it is the industry standard.

- Project: Here we are asked to use `NLTK` instead

- TextBlob as a consequence to be switched out for [spaCy-TextBlob](https://spacy.io/universe/project/spacy-textblob)

Related issues: [please specify]

## Description:

What are you up to? Fill us in :)

## I solemnly swear that:

- [ ] I ran the hugo server and looked at my changed in the browser with my own eyes
- [ ] I ran the linter and there were no errors
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
