### PR TITLE
Expo tutorial project - content update

### DIFF
--- a/content/react-native/expo-tutorial-project/_index.md
+++ b/content/react-native/expo-tutorial-project/_index.md
@@ -30,6 +30,13 @@ If your splash screen doesn't show up in your web browser, don't panic, it's nor
 
 If you are using the Expo go app on your phone then you might notice that even after updating your splash screen, nothing changes in the app. You need to close Expo Go completely and re-open it. When you reload your app then the new splash screen will show up.
 
+### Emoji sticker not showing up on Chrome in Linux
+
+If the select an emoji sticker doesn't show up on the web version in chrome, but it works on an Android or IOS simulator/device, try:
+
+- clear your browser cookies, this works sometimes.
+- use a different browser for testing the web version, Firefox seems to work fine.
+
 ## Video please
 
 Going forward, we will require a video demo of all the apps you create during this course. If there is a multi-part project then we will always want to be able to access videos of any part of the project.

--- a/content/react-native/expo-tutorial-project/_index.md
+++ b/content/react-native/expo-tutorial-project/_index.md
@@ -24,38 +24,6 @@ Once you have finished the basic tutorial, improve it by doing the following:
 
 ## Common problems
 
-### Section: Sharing the image
-
-If you get the error: `Uncaught (in promise) ReferenceError: Platform is not defined` then double check that your imports include `Platform`. Eg:
-
-```
-import { Image, StyleSheet, Text, TouchableOpacity, View , Platform} from 'react-native';
-```
-
-### Section: Handling platform differences
-
-The tutorial makes use of a service called `anonomousfiles`. This service does go down from time to time. If you get an error that looks like this:
-
-```
-Access to fetch at 'https://api.anonymousfiles.io/' from origin 'http://localhost:19006' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource. If an opaque response serves your needs, set the request's mode to 'no-cors' to fetch the resource with CORS disabled.
-```
-
-Then you probably did everything right. The anonomous files service is a web api that accepts an image and responds with a sharable url. If this isn't working then just hard-code a url for now.
-
-Eg:
-
-```
-    if (Platform.OS === 'web') {
-      // let remoteUri = await uploadToAnonymousFilesAsync(pickerResult.uri);
-      const remoteUri = "https://nerdist.com/wp-content/uploads/2020/07/maxresdefault.jpg"
-      setSelectedImage({ localUri: pickerResult.uri, remoteUri });
-    } else {
-      setSelectedImage({ localUri: pickerResult.uri, remoteUri: null });
-    }
-```
-
-This is ok because the aim of this tutorial is just to understand how ReactNative works.
-
 ### Configuring a splash screen and app icon
 
 If your splash screen doesn't show up in your web browser, don't panic, it's normal.

--- a/content/react-native/expo-tutorial-project/_index.md
+++ b/content/react-native/expo-tutorial-project/_index.md
@@ -17,7 +17,7 @@ Start off by doing [this tutorial](https://docs.expo.dev/tutorial/planning/). Ma
 
 Once you have finished the basic tutorial, improve it by doing the following:
 
-1. Please be sure to include a `.nvmrc` file in your project submission. If you don't know what that means then go read about NVM.
+1. Include a `.nvmrc` file in your project submission. If you don't know what that means then go read about NVM.
 2. Refactor your code so that each component is in a separate file.
 3. Add a new button to clear the selected image and selected sticker/emoji.
 4. Make sure that you use `const` wherever appropriate. The tutorial uses `let` for everything, it's not always the best option. Most things are actually constant.

--- a/content/react-native/expo-tutorial-project/_index.md
+++ b/content/react-native/expo-tutorial-project/_index.md
@@ -2,8 +2,8 @@
 _db_id: 785
 content_type: project
 flavours:
-- javascript
-- typescript
+  - javascript
+  - typescript
 ready: true
 submission_type: repo
 title: Expo tutorial project
@@ -13,15 +13,13 @@ Alrighty, time to get your hands dirty.
 
 Start off by doing [this tutorial](https://docs.expo.dev/tutorial/planning/). Make sure that you understand what you are doing, we'll be doing much harder stuff soon.
 
-Please be sure to include a `.nvmrc` file in your project submission. If you don't know what that means then go read about NVM.
-
-## Moar requirements
+## More requirements
 
 Once you have finished the basic tutorial, improve it by doing the following:
 
-1. Refactor your code so that each component is in a separate file
-2. Add a new button to clear the selected image state
-3. Create a reusable Button component to clean up duplication of TouchableOpacity / Text
+1. Please be sure to include a `.nvmrc` file in your project submission. If you don't know what that means then go read about NVM.
+2. Refactor your code so that each component is in a separate file.
+3. Add a new button to clear the selected image and selected sticker/emoji.
 4. Make sure that you use `const` wherever appropriate. The tutorial uses `let` for everything, it's not always the best option. Most things are actually constant.
 
 ## Common problems
@@ -33,6 +31,7 @@ If you get the error: `Uncaught (in promise) ReferenceError: Platform is not def
 ```
 import { Image, StyleSheet, Text, TouchableOpacity, View , Platform} from 'react-native';
 ```
+
 ### Section: Handling platform differences
 
 The tutorial makes use of a service called `anonomousfiles`. This service does go down from time to time. If you get an error that looks like this:
@@ -41,9 +40,10 @@ The tutorial makes use of a service called `anonomousfiles`. This service does g
 Access to fetch at 'https://api.anonymousfiles.io/' from origin 'http://localhost:19006' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource. If an opaque response serves your needs, set the request's mode to 'no-cors' to fetch the resource with CORS disabled.
 ```
 
-Then you probably did everything right. The anonomous files service is a web api that accepts an image and responds with a sharable url.  If this isn't working then just hard-code a url for now.
+Then you probably did everything right. The anonomous files service is a web api that accepts an image and responds with a sharable url. If this isn't working then just hard-code a url for now.
 
 Eg:
+
 ```
     if (Platform.OS === 'web') {
       // let remoteUri = await uploadToAnonymousFilesAsync(pickerResult.uri);

--- a/content/react-native/expo-tutorial-project/_index.md
+++ b/content/react-native/expo-tutorial-project/_index.md
@@ -19,7 +19,7 @@ Once you have finished the basic tutorial, improve it by doing the following:
 
 1. Include a `.nvmrc` file in your project submission. If you don't know what that means then go read about NVM.
 2. Refactor your code so that each component is in a separate file.
-3. Add a new button to clear the selected image and selected sticker/emoji.
+3. Add a new button to clear the selected image and the selected emoji sticker.
 4. Make sure that you use `const` wherever appropriate. The tutorial uses `let` for everything, it's not always the best option. Most things are actually constant.
 
 ## Common problems

--- a/content/react-native/expo-tutorial-project/_index.md
+++ b/content/react-native/expo-tutorial-project/_index.md
@@ -85,6 +85,4 @@ Make sure your video is marked as UNLISTED or PUBLIC, then link to the video in 
 
 ### Screen mirroring
 
-If you are using a physical device for a project then it would likely be necessary to mirror your screen. That is, get your phone's display to show up on your computer. There are many excellent tools that you can use for this:
-
-https://fossbytes.com/android-screen-mirroring-apps-pc/
+If you are using a physical device for a project then it would likely be necessary to mirror your screen. That is, get your phone's display to show up on your computer. There are many excellent tools that you can use for this: [6 Methods To Mirror Android Screen To PC (No Root Apps) In 2022](https://fossbytes.com/android-screen-mirroring-apps-pc/)


### PR DESCRIPTION
Related issues: [please specify]

## Description:
Main issue: **The expo tutorial seems to have changed(from ImageShare to StickerSmash)** - this PR is to update the content to be more relevant to the newer tutorial.

- Made the `.npmrc` instructions part of the "more requirements" section
- remove and add content in the "more requirements" section to be relevant to the new tutorial
- remove and add content in the "common problems" section to be relevant to the new tutorial
- small markdown formatting

## I solemnly swear that:

- [x] I ran the hugo server and looked at my changed in the browser with my own eyes
- [x] I ran the linter and there were no errors
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
