### PR TITLE
Simple calculator - fix broken python and java links 

### DIFF
--- a/content/projects/tdd/simple-calculator-part1/_index.md
+++ b/content/projects/tdd/simple-calculator-part1/_index.md
@@ -76,13 +76,13 @@ Please name your files and folders like this:
 
 Please take a look at this topic to see an explanation of the required directory structure.
 
-{{< contentlink "topics/python-specific/automated-testing-with-pytest" >}}
+{{< contentlink path="topics/python-specific/automated-testing-with-pytest" >}}
 
 ### Java
 
 Make use of Gradle from the command line to set up your project. You can learn more about Gradle here:
 
-{{< contentlink "gradle/introduction" >}}
+{{< contentlink path="gradle/introduction" >}}
 
 Your directory structure should look like this:
 


### PR DESCRIPTION
Related issues: [please specify]
https://umuzi-projects.monday.com/boards/1254743632/pulses/1274930574

## Description:

Fixed broken links

before:
![image](https://github.com/Umuzi-org/ACN-syllabus/assets/54069197/f5eef40c-30b7-4e92-b270-b73c6ac4ad64)

after:
![image](https://github.com/Umuzi-org/ACN-syllabus/assets/54069197/add92502-a6fe-4039-83f3-785ba7cd3a48)


## I solemnly swear that:

- [x] I ran the hugo server and looked at my changed in the browser with my own eyes
- [x] I ran the linter and there were no errors
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
