### PR TITLE
returns empty string comment fix and make all sounds parentheses

### DIFF
--- a/content/projects/oop/animals/part1/_index.md
+++ b/content/projects/oop/animals/part1/_index.md
@@ -227,7 +227,7 @@ dog1 = Dog()
 dog2 = Dog()
 cat = Cat()
 
-home.make_all_sounds() // this returns an empty ArrListay
+home.make_all_sounds() # this returns an empty ArrListay
 home.adopt_pet(dog1) # 1
 home.make_all_sounds()
 # this returns:
@@ -240,7 +240,7 @@ home.make_all_sounds()
 # ["Bark", "Meow"]
 
 home.adopt_pet(dog2) # 3
-home.make_all_sounds
+home.make_all_sounds()
 # this returns:
 # ["Bark", "Meow", "Bark"]
 ```


### PR DESCRIPTION
Related issues: [please specify]

## Description:

A small change to a block code in animals part 1 .md file where a comment was commented with Java syntax and not Python syntax and parentheses were forgotten at the end of make_all_sounds()

## I solemnly swear that:

hopefully, changes to the .md file don't require these checks because I don't know how to run these checks.

- [] I ran the hugo server and looked at my changed in the browser with my own eyes
- [ ] I ran the linter and there were no errors
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
