### PR TITLE
Remove everything to do with topic_needs_review - syllabus

### DIFF
--- a/content/topics/tilde/understanding-the-review-column/_index.md
+++ b/content/topics/tilde/understanding-the-review-column/_index.md
@@ -1,9 +1,11 @@
 ---
 _db_id: 585
-content_type: topic
+content_type: project
+flavours:
+  - any_language
 ready: true
+submission_type: link
 title: Understanding the review column
-topic_needs_review: true
 ---
 
 The review column causes a lot of confusion for a lot of people. A lot of students do weird things and end up getting bad reviews.
@@ -72,7 +74,7 @@ We wouldn't ask you to review other people's work if it wasn't good for you :)
 
 ## Leave complete feedback
 
-If there are 5 things wrong with a project submission then explain all 5. Make sure you give your peer enough information so that they can sort out everything as qickly as possible.
+If there are 5 things wrong with a project submission then explain all 5. Make sure you give your peer enough information so that they can sort out everything as quickly as possible.
 
 Set your peers up for success and efficiency!
 
@@ -114,7 +116,7 @@ By reviewing code and stating your opinion you will constantly test and upgrade 
 
 ## Instructions:
 
- You need to demonstrate your understanding of how the review column works before putting this topic card into the review column.
+ You need to demonstrate your understanding of how the review column works before putting this project card into the review column.
  
 **FIRST** the below project card should be marked competent:
 
@@ -124,12 +126,15 @@ By reviewing code and stating your opinion you will constantly test and upgrade 
 
 **Tilde project tutorial: How Repo projects work** 
 
-If the relevant project card(s) aren't complete, you will be red-flagged for this topic card if you move it to the review column. Instructions must be followed.
+If the relevant project card(s) aren't complete, you will be red-flagged for this project card if you move it to the review column. Instructions must be followed.
+
+## Note about submission format
+
+On Tilde you will notice that this card is asking for a link submission. **Please don't worry about submitting a link**
 
 ## Check your understanding!
 
 - If you are learning to code, when should you put your repo card into the review column?
-- What are the requirements for link projects to be moved to the review column?
 - What is the priority of a student who owes reviews to their peers?
 - Why is it important to have high standards when reviewing other people's work?
 - What should you do if there are multiple issues with a project submission?

--- a/content/topics/tilde/understanding-the-review-column/_index.md
+++ b/content/topics/tilde/understanding-the-review-column/_index.md
@@ -2,9 +2,14 @@
 _db_id: 585
 content_type: project
 flavours:
-  - any_language
+ - none
+protect_main_branch: false
 ready: true
-submission_type: link
+submission_type: repo
+tags:
+ - close_on_peer_reviews
+ - skill/tilde
+ready: true
 title: Understanding the review column
 ---
 
@@ -132,13 +137,19 @@ If the relevant project card(s) aren't complete, you will be red-flagged for thi
 
 On Tilde you will notice that this card is asking for a link submission. **Please don't worry about submitting a link**
 
-## Check your understanding!
+## Please answer the following questions:
 
-- If you are learning to code, when should you put your repo card into the review column?
-- What is the priority of a student who owes reviews to their peers?
-- Why is it important to have high standards when reviewing other people's work?
-- What should you do if there are multiple issues with a project submission?
-- What are the benefits of participating in the review process?
-- What should you do if a staff member disagrees with your review?
-- What are the consequences of marking something as competent and a staff member marking it as not yet competent?
-- How should you prioritize which cards to review first?
+1.  If you are learning to code, when should you put your repo card into the review column?
+2.  What is the priority of a student who owes reviews to their peers?
+3.  Why is it important to have high standards when reviewing other people's work?
+4.  What should you do if there are multiple issues with a project submission?
+5.  What are the benefits of participating in the review process?
+6.  What should you do if a staff member disagrees with your review?
+7.  What are the consequences of marking something as competent and a staff member marking it as not yet competent?
+8.  How should you prioritize which cards to review first?
+
+## How to submit your work
+
+Please follow the following instructions to submit your work:
+
+{{< contentlink path="project-submission-instructions/markdown-questions" >}}

--- a/contribute.md
+++ b/contribute.md
@@ -191,12 +191,6 @@ Some projects can be done in js or typescript. Some projects can be done in any 
 
 The available flavours are specified in `flavours`.
 
-#### <a name="topic"></a> Topic specific stuff
-
-Generally Topics turn into Tilde cards that the student can just move to complete on their own. But sometimes we want a staff member to check on the student and make sure that they did the work to a high enough quality.
-
-`topic_needs_review: true` can be added to a topic's frontmatter to signify this.
-
 #### <a name="goodies"></a> Project specific goodies
 
 The `submission_type` says what form the project should take and describes how the Tilde cards should behave. It can have the following values:

--- a/lint.py
+++ b/lint.py
@@ -91,7 +91,6 @@ def check_one_file_frontmatter(file_path):
         "tags",
         "story_points",
         "flavours",
-        "topic_needs_review",
         "ncit_standards",
         "ncit_specific_outcomes",
         "learning_outcomes",


### PR DESCRIPTION
Related issues: https://umuzi-projects.monday.com/boards/1274815998/pulses/1388063017

## Description:

I changed the only topic that was using `topic_needs_review` to a project with a link submission.

I updated the instructions to instruct learners not to worry about submitting a link.
This is just for the purpose of demo-ing the how the review column works. I think it should still work because the foundation assessment sessions also behave in the same way.

Maybe there's a better way?

## I solemnly swear that:

- [x] I ran the hugo server and looked at my changed in the browser with my own eyes
- [x] I ran the linter and there were no errors
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
