### PR TITLE
Update _index.md

### DIFF
--- a/content/projects/data-science-specific/assertive-programming-tricks-for-pandas/_index.md
+++ b/content/projects/data-science-specific/assertive-programming-tricks-for-pandas/_index.md
@@ -6,7 +6,6 @@ flavours:
 prerequisites:
   hard:
   - topics/intro-to-assertive-programming
-  - projects/data-science-specific/data-wrangling
 submission_type: repo
 title: Assertive programming helpers for Pandas
 ---


### PR DESCRIPTION
Related issues: One of the learners raised this on hesk support, it seems truly weird so I removed data wrangling as a prerequisite for assertive programming tricks for pandas project: 

> When looking at the syllabus prerequisites for Data Wrangling, Assertive programming helpers for pandas is listed as a hard prerequisite. When you look at the syllabus webpage for Assertive programming, the opposite is true as well. When you look at the tilde board of a data science student who has data wrangling in progress or in review, you will notice that the assertive programming helpers card is grey, yet the updated instructions for data wrangling state that you need to use what you learnt in assertive programming helpers to answer the questions in Data wrangling

## Description:

What are you up to? Fill us in :)

## I solemnly swear that:

- [x] I ran the hugo server and looked at my changed in the browser with my own eyes
- [x] I ran the linter and there were no errors
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
