### PR TITLE
Expo tutorial project - Broken Link fix

### DIFF
--- a/content/react-native/expo-tutorial-project/_index.md
+++ b/content/react-native/expo-tutorial-project/_index.md
@@ -12,7 +12,7 @@ title: Expo tutorial project
 
 Alrighty, time to get your hands dirty.
 
-Start off by doing [this tutorial](https://docs.expo.dev/tutorial/planning/). Make sure that you understand what you are doing, we'll be doing much harder stuff soon.
+Start off by doing [this tutorial](https://docs.expo.dev/tutorial/introduction/). Make sure that you understand what you are doing, we'll be doing much harder stuff soon.
 
 ## More requirements
 


### PR DESCRIPTION
Related issues: [please specify]

## Description:
https://syllabus.africacode.net/react-native/expo-tutorial-project/ broken link
![Screenshot 2025-06-13 115122](https://github.com/user-attachments/assets/925fe1a2-92f5-4bff-90c4-192d410304bc)
After
![Screenshot 2025-06-13 115624](https://github.com/user-attachments/assets/af5b538d-af0b-4ec7-a3cb-d4e44479e960)


What are you up to? Fill us in :)

## I solemnly swear that:

- [x] I ran the hugo server and looked at my changed in the browser with my own eyes
- [x] I ran the linter and there were no errors
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
